### PR TITLE
Remove gemini-cli references

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,7 +58,7 @@ claude/skills/ → ~/.claude/skills
 **mise** (mise/config.toml):
 - 言語: node, python, go, deno
 - CLIツール: gh, glab, watchexec
-- npm globals: claude-code, gemini-cli等
+- npm globals: claude-code等
 - aqua経由: pinact
 - go経由: deck
 - ubi経由: glab

--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -79,10 +79,6 @@ CLI Tool List:
 - When: Managing GCP resources (compute, storage, APIs, IAM)
 - Ex: `gcloud compute instances list --project=X`
 
-**gemini**: For web_fetch, text generation, retrospective analysis.
-- When: Need web content, complex text generation, or project insights
-- Usage: `gemini --help`
-
 **pinact**: Pinact CLI for pinning GitHub Actions SHA versions.
 - When: Pinning GitHub Actions in workflows
 - Usage: `pinact --help`


### PR DESCRIPTION
## Changes

- gemini-cliへの言及をCLAUDE.md（プロジェクト/グローバル）から削除
- mise config.tomlからは前回PRで削除済み
