### PR TITLE
Change git-wt basedir to .git/wt

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -22,4 +22,4 @@
 	process = git-lfs filter-process
 	required = true
 [wt]
-	basedir = /tmp/{gitroot}-wt
+	basedir = {gitroot}/.git/wt


### PR DESCRIPTION
## Summary
- git-wt の worktree 配置先を `/tmp/{gitroot}-wt` から `{gitroot}/.git/wt` に変更
- worktree をリポジトリ内に配置することで、tmpクリア時の消失を防止