### PR TITLE
feat(claude): add slack-notify skill

### DIFF
--- a/claude/skills/slack-notify/SKILL.md
+++ b/claude/skills/slack-notify/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: slack-notify
+description: "作業完了時にSlackのIncoming Webhookで完了報告を送る。環境変数CLAUDE_SLACK_NOTIFY_WEBHOOK_URLが未設定なら何もしない。「Slack通知」「完了報告」で発動。"
+user-invocable: true
+allowed-tools: "Bash(curl:*)"
+---
+
+# Slack Notify
+
+作業内容を要約し、SlackのIncoming Webhookで完了報告を送信する。
+
+## 前提条件
+
+環境変数 `CLAUDE_SLACK_NOTIFY_WEBHOOK_URL` が設定されていること。
+
+## 実行手順
+
+### 1. 環境変数の確認
+
+`CLAUDE_SLACK_NOTIFY_WEBHOOK_URL` が未設定または空の場合、何もせずに終了する。エラーメッセージもユーザーへの報告も出さない。即座にセッションに戻る。
+
+### 2. 作業内容の要約
+
+現在のセッションで行った作業を要約する。`$ARGUMENTS` が与えられている場合は、その内容をコンテキストとして使用する。
+
+### 3. メッセージ組み立て
+
+ヘッダ行は固定。本文は呼び出しコンテキストに応じて自由に構成する。
+
+- ヘッダ: `:white_check_mark: *Claude Code 作業完了*`
+- 本文: エージェントが状況に応じて構成する（何のタスクが完了したのか、結果がどうだったのかを完結にまとめる）
+- 形式: Slack mrkdwn
+
+### 4. メッセージ送信
+
+`jq -n` でJSONを組み立て、`curl` で送信する。
+
+```bash
+jq -n --arg text "$MESSAGE" '{"text": $text}' | \
+  curl -s -o /dev/null -w "%{http_code}" -X POST "$CLAUDE_SLACK_NOTIFY_WEBHOOK_URL" \
+    -H "Content-Type: application/json" -d @-
+```
+
+HTTPステータスコードが200以外の場合のみ、送信失敗をユーザーに報告する。
+
+## 制約
+
+- Block Kitは使わない。`text`フィールドのみ使用する。
+- メッセージは日本語で構成する。
+- 秘密情報（トークン、パスワード、APIキー等）をメッセージに含めない。

--- a/claude/skills/slack-notify/SKILL.md
+++ b/claude/skills/slack-notify/SKILL.md
@@ -2,7 +2,7 @@
 name: slack-notify
 description: "作業完了時にSlackのIncoming Webhookで完了報告を送る。環境変数CLAUDE_SLACK_NOTIFY_WEBHOOK_URLが未設定なら何もしない。「Slack通知」「完了報告」で発動。"
 user-invocable: true
-allowed-tools: "Bash(curl:*)"
+allowed-tools: "Bash(~/.claude/skills/slack-notify/send.sh:*)"
 ---
 
 # Slack Notify
@@ -33,15 +33,13 @@ allowed-tools: "Bash(curl:*)"
 
 ### 4. メッセージ送信
 
-`jq -n` でJSONを組み立て、`curl` で送信する。
+スキルディレクトリ内の `send.sh` を使って送信する。
 
 ```bash
-jq -n --arg text "$MESSAGE" '{"text": $text}' | \
-  curl -s -o /dev/null -w "%{http_code}" -X POST "$CLAUDE_SLACK_NOTIFY_WEBHOOK_URL" \
-    -H "Content-Type: application/json" -d @-
+~/.claude/skills/slack-notify/send.sh "<組み立てたメッセージ>"
 ```
 
-HTTPステータスコードが200以外の場合のみ、送信失敗をユーザーに報告する。
+送信失敗時（非ゼロ終了）のみ、ユーザーに報告する。
 
 ## 制約
 

--- a/claude/skills/slack-notify/send.sh
+++ b/claude/skills/slack-notify/send.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Usage: send.sh <message>
+# Env: CLAUDE_SLACK_NOTIFY_WEBHOOK_URL
+
+if [[ -z "${CLAUDE_SLACK_NOTIFY_WEBHOOK_URL:-}" ]]; then
+  exit 0
+fi
+
+MESSAGE="${1:?Usage: send.sh <message>}"
+
+HTTP_STATUS=$(jq -n --arg text "$MESSAGE" '{"text": $text}' | \
+  curl -s -o /dev/null -w "%{http_code}" -X POST "$CLAUDE_SLACK_NOTIFY_WEBHOOK_URL" \
+    -H "Content-Type: application/json" -d @-)
+
+if [[ "$HTTP_STATUS" != "200" ]]; then
+  echo "Error: Slack webhook returned HTTP $HTTP_STATUS" >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- 作業完了時にSlack Incoming Webhookで通知を送る `slack-notify` スキルを追加
- 環境変数 `CLAUDE_SLACK_NOTIFY_WEBHOOK_URL` が未設定の場合は何もせずセッションに戻る
- `jq` + `curl` でメッセージを送信、Block Kit不使用のシンプルなmrkdwnテキスト

## Usage

```fish
# 環境変数を設定（各自の環境で）
set -gx CLAUDE_SLACK_NOTIFY_WEBHOOK_URL "https://hooks.slack.com/services/T.../B.../xxx"
```

```
/slack-notify
```
