### PR TITLE
fix(claude): slack-notify fixed message with env-based mention

### DIFF
--- a/claude/skills/slack-notify/SKILL.md
+++ b/claude/skills/slack-notify/SKILL.md
@@ -2,7 +2,7 @@
 name: slack-notify
 description: "WHEN: PROACTIVELY after completing a substantial task (PR merge, feature implementation, bug fix, investigation)—invoke WITHOUT waiting for user request. SKIP for trivial/instant tasks (typo fix, single-line change, quick question answer, config tweak). Also invokable manually via /slack-notify. Sends a completion notification to Slack via Incoming Webhook. Does nothing if CLAUDE_SLACK_NOTIFY_WEBHOOK_URL is not set."
 user-invocable: true
-allowed-tools: "Bash(~/.claude/skills/slack-notify/send.sh:*)"
+allowed-tools: "Bash(~/.claude/skills/slack-notify/send.sh)"
 ---
 
 # Slack Notify
@@ -19,24 +19,12 @@ allowed-tools: "Bash(~/.claude/skills/slack-notify/send.sh:*)"
 
 `CLAUDE_SLACK_NOTIFY_WEBHOOK_URL` が未設定または空の場合、何もせずに終了する。エラーメッセージもユーザーへの報告も出さない。即座にセッションに戻る。
 
-### 2. 作業内容の要約
+### 2. メッセージ送信
 
-現在のセッションで行った作業を要約する。`$ARGUMENTS` が与えられている場合は、その内容をコンテキストとして使用する。
-
-### 3. メッセージ組み立て
-
-ヘッダ行は固定。本文は呼び出しコンテキストに応じて自由に構成する。
-
-- ヘッダ: `@lacolaco 作業完了。`
-- 本文: エージェントが状況に応じて構成する（何のタスクが完了したのかを完結にまとめる。内容や結果には触れない。）
-- 形式: Slack mrkdwn
-
-### 4. メッセージ送信
-
-スキルディレクトリ内の `send.sh` を使って送信する。
+スキルディレクトリ内の `send.sh` を実行する。メッセージはスクリプト内に固定されている。
 
 ```bash
-~/.claude/skills/slack-notify/send.sh "<組み立てたメッセージ>"
+~/.claude/skills/slack-notify/send.sh
 ```
 
 送信失敗時（非ゼロ終了）のみ、ユーザーに報告する。

--- a/claude/skills/slack-notify/send.sh
+++ b/claude/skills/slack-notify/send.sh
@@ -1,14 +1,18 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Usage: send.sh <message>
+# Usage: send.sh
 # Env: CLAUDE_SLACK_NOTIFY_WEBHOOK_URL
 
 if [[ -z "${CLAUDE_SLACK_NOTIFY_WEBHOOK_URL:-}" ]]; then
   exit 0
 fi
 
-MESSAGE="${1:?Usage: send.sh <message>}"
+if [[ -z "${CLAUDE_SLACK_NOTIFY_MENTION:-}" ]]; then
+  MESSAGE="claude codeのタスクが完了しました"
+else
+  MESSAGE="<@${CLAUDE_SLACK_NOTIFY_MENTION}> claude codeのタスクが完了しました"
+fi
 
 HTTP_STATUS=$(jq -n --arg text "$MESSAGE" '{"text": $text}' | \
   curl -s -o /dev/null -w "%{http_code}" -X POST "$CLAUDE_SLACK_NOTIFY_WEBHOOK_URL" \


### PR DESCRIPTION
send.shを固定メッセージ+引数なしに変更。permission承認が毎回求められる問題を解消。メンションはCLAUDE_SLACK_NOTIFY_MENTION環境変数で設定。