### PR TITLE
chore(claude): move PermissionRequest hook to settings.local.json

### DIFF
--- a/claude/settings.json
+++ b/claude/settings.json
@@ -78,18 +78,6 @@
       }
     }
   },
-  "hooks": {
-    "PermissionRequest": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "terminal-notifier -message '承認待ちです' -title 'Claude Code' -activate \"${__CFBundleIdentifier:-com.apple.Terminal}\""
-          }
-        ]
-      }
-    ]
-  },
   "language": "Japanese",
   "alwaysThinkingEnabled": true,
   "effortLevel": "high",


### PR DESCRIPTION
## Summary

- `PermissionRequest` hook は `terminal-notifier`（macOS 専用の GUI 通知）を呼び出すマシン依存設定
- リポジトリ管理の `settings.json` にあるべきではなく、`.gitignore` される `~/.claude/settings.local.json` に移動
- 移動先ファイルは `.gitignore_global` の `.claude/**/*.local.*` により除外

## Test plan

- [ ] `jq -e '.hooks.PermissionRequest' ~/.claude/settings.local.json` で移動先に存在することを確認
- [ ] 承認待ち時に通知が出ることを確認
