### PR TITLE
feat(gitconfig): add ~/.gitconfig.local include hook

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -23,3 +23,5 @@
 	required = true
 [wt]
 	basedir = {gitroot}/.git/wt
+[include]
+	path = ~/.gitconfig.local

--- a/.gitconfig.local.example
+++ b/.gitconfig.local.example
@@ -1,0 +1,29 @@
+# Template for ~/.gitconfig.local (local-only, NOT committed).
+#
+# Loaded via `[include] path = ~/.gitconfig.local` in .gitconfig.
+# Missing file is silently ignored by Git, so no setup is required to
+# fall through to the default user identity.
+#
+# Use this file to keep host-specific overrides (work email, signing keys,
+# private remote auth helpers, etc.) out of the public dotfiles repo.
+
+# --- Pattern: switch user.email per forge instance via remote URL ---
+#
+# `hasconfig:remote.*.url:<glob>` matches against any remote URL configured
+# in the current repository. The glob uses gitignore-style matching:
+#   - `*`     does NOT cross `/`
+#   - `**/`   matches zero or more leading path components
+#   - `/**`   matches zero or more trailing path components
+# Wrapping the host with `**/*host*/**` covers both SSH (`git@host:org/repo`)
+# and HTTPS (`https://host/org/repo`) URL forms.
+#
+# [includeIf "hasconfig:remote.*.url:**/*git.example.com*/**"]
+# 	path = ~/.gitconfig.local.example-com
+
+# --- The included file then defines the override identity ---
+#
+# (saved at the path referenced above, e.g. ~/.gitconfig.local.example-com)
+#
+# [user]
+# 	email = me@example.com
+# 	signingkey = ~/.ssh/id_example_ed25519.pub


### PR DESCRIPTION
## Summary
- `.gitconfig` 末尾に `[include] path = ~/.gitconfig.local` を追加。ホスト固有のメールアドレス等、公開リポジトリにコミットしたくないローカル機密設定の分離フックを提供する
- 当該ファイルが存在しない場合 Git は include を黙って無視するため、新規環境でも何もせずデフォルト ID にフォールスルーする
- `.gitconfig.local.example` を新設し、remote URL ベースの `includeIf` による `user.email` 切替パターンを明示（`**/*host*/**` で SSH/HTTPS 両形式に対応）

## Test plan
- [x] `~/.gitconfig.local` 不在時に既存の `user.email` が変わらないことを確認
- [x] `~/.gitconfig.local` 経由で `includeIf "hasconfig:remote.*.url:..."` がリモート URL にマッチしたとき `user.email` が切り替わることを SSH/HTTPS 両形式で確認
- [x] マッチしないリモート（例: `git@github.com:...`）ではデフォルト ID のままであることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)