### PR TITLE
chore(gitignore): ignore .gitconfig.local* except example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,8 @@ fish/functions/fisher.fish
 fish/functions/bass.fish
 fish/functions/__bass.py
 karabiner/automatic_backups
+
+# Local-only git config overrides (see .gitconfig.local.example)
+.gitconfig.local
+.gitconfig.local.*
+!.gitconfig.local.example


### PR DESCRIPTION
## Summary
- リポジトリ内に誤って `.gitconfig.local` 実体ファイルが作成・コミットされるのを防ぐ防御策
- ホームに置くべきローカル機密設定 (#34 で導入) がリポジトリ root に紛れ込むケースを `.gitignore` で先回りブロック
- テンプレート `.gitconfig.local.example` は否定パターンで追跡対象に残す

## Test plan
- [x] `.gitconfig.local` / `.gitconfig.local.twogate` が `git status --ignored` で Ignored 扱いになることを確認
- [x] `.gitconfig.local.example` は引き続きトラッキング対象であることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)