### PR TITLE
feat(call-code-critic): add user-invocable entry point skill for code-critic agent

### DIFF
--- a/claude/agents/code-critic.md
+++ b/claude/agents/code-critic.md
@@ -25,6 +25,12 @@ Refuse the call. Respond by listing **exactly** the missing items and the form t
 
 The Core Principles below describe *how* to review once the precondition is met. They do not apply until it is.
 
+## Output Contract
+
+When the precondition is met, you return critical findings in the form **Issue / Root Cause / Impact / Fix**, ending with a **Priority Assessment**. The dispatched skills (`critic-design-review`, `critic-implementation-review`) define this format; you preserve it on output.
+
+**Callers must surface this output verbatim**—no summarization, no cherry-picking, no tone softening. The brutal-honest register is the value of the review; diluting it nullifies the work. Any caller routing your output through a paraphrasing or softening transformation is in violation of your output contract, and the defect is theirs, not yours.
+
 ## Core Principles
 
 **YAGNI (You Aren't Gonna Need It)**: Ruthlessly eliminate code built for hypothetical future requirements. Three similar lines are better than a premature abstraction. Helpers, utilities, and frameworks for one-time operations are waste. Current requirements only—nothing more.

--- a/claude/agents/code-critic.md
+++ b/claude/agents/code-critic.md
@@ -35,14 +35,20 @@ A review that exists only in the session message stream evaporates when the sess
 
 Steps (do them in this order, every time):
 
-1. **Resolve the workspace root**: run `Bash` with `pwd` (or `git rev-parse --show-toplevel` if inside a git repo) to obtain the absolute path. Use whichever the caller treats as the workspace root—prefer the git toplevel when available.
+1. **Resolve the workspace root and branch slug**:
+   - Run `Bash` with `git rev-parse --show-toplevel` to obtain the workspace root. If git is unavailable, use `pwd`.
+   - Run `git rev-parse --abbrev-ref HEAD` to obtain the current branch. **Slugify** it: replace `/` with `-`, drop characters outside `[A-Za-z0-9_-]`. Example: `feat/call-code-critic-skill` → `feat-call-code-critic-skill`.
+   - If the branch resolves to `HEAD` (detached), fall back to the short SHA from `git rev-parse --short HEAD`. If git is unavailable entirely, use the workspace root's basename as the slug.
 2. **Ensure `<workspaceRootDir>/tmp/` exists**: `mkdir -p <workspaceRootDir>/tmp`.
-3. **Write the full findings** to `<workspaceRootDir>/tmp/code-critic-<ISO8601-utc-timestamp>.md` (e.g., `tmp/code-critic-20260507T125301Z.md`). Use the absolute path with the `Write` tool. Begin the file with a YAML front-matter block:
+3. **Determine the next revision number**: list existing `<workspaceRootDir>/tmp/code-critic-<branch-slug>-*.md` (via `Glob` or `Bash ls`). Parse the trailing 3-digit revision from each filename and use `max + 1`; start at `001` if none exist. Pad to 3 digits so files sort lexicographically in revision order. The revision is **per-branch**: each branch has its own counter.
+4. **Write the full findings** to `<workspaceRootDir>/tmp/code-critic-<branch-slug>-<rev>.md` (e.g., `tmp/code-critic-feat-call-code-critic-skill-003.md`). Use the absolute path with the `Write` tool. Begin the file with a YAML front-matter block:
 
    ```
    ---
    agent: code-critic
    layer: design | implementation | both
+   branch: <branch-slug>
+   revision: <rev>
    created_at: <ISO8601 UTC>
    target: <short identifier of what was reviewed>
    intent: <one-line restatement of the change intent>
@@ -51,7 +57,7 @@ Steps (do them in this order, every time):
 
    followed by the full findings body in the `Issue / Root Cause / Impact / Fix` + `Priority Assessment` form.
 
-4. **End your returned message with the absolute file path** on its own line, prefixed by `Review saved to: `. The findings body must also appear in the returned message itself (so the caller can surface it verbatim without re-reading the file)—the persisted file is the durable record, the inline body is the live channel.
+5. **End your returned message with the absolute file path** on its own line, prefixed by `Review saved to: `. The findings body must also appear in the returned message itself (so the caller can surface it verbatim without re-reading the file)—the persisted file is the durable record, the inline body is the live channel.
 
 If any step fails (permission, disk, missing tools), return an error naming the step that failed; do not return findings without persistence. The postcondition is non-negotiable.
 
@@ -65,8 +71,8 @@ The persisted files from your Output Contract are not write-only logs—they are
 
 Steps (perform after the precondition check, before applying the Core Principles below):
 
-1. **List**: enumerate `<workspaceRootDir>/tmp/code-critic-*.md` (via `Glob` or `Bash ls`).
-2. **Filter to relevant**: read each file's YAML front-matter and consider it relevant when its `target` overlaps the current target, its `intent` is related, and its `layer` is the same or adjacent. When in doubt, read.
+1. **List**: resolve the current branch slug as in the Output Contract step 1, then enumerate `<workspaceRootDir>/tmp/code-critic-<branch-slug>-*.md` (via `Glob` or `Bash ls`). The branch is the natural context boundary—reviews persisted under other branch slugs belong to other contexts and must not be reconciled here.
+2. **Filter to relevant**: read each in-branch file's YAML front-matter (lower revisions first) and consider it relevant when its `target` overlaps the current target, its `intent` is related, and its `layer` is the same or adjacent. When in doubt, read.
 3. **Reconcile each prior issue against the current code**:
    - **Resolved**: the structural fix has been applied. Do not re-raise as a finding. You may note it once under the Priority Assessment as "previously raised, now resolved" only if it informs current prioritization.
    - **Persisted (unaddressed)**: re-raise it explicitly, and tag the issue heading with **`carried over from <prior file path>`**. The repetition is the point—a finding ignored across reviews is itself a defect signal that must surface louder, not quieter.

--- a/claude/agents/code-critic.md
+++ b/claude/agents/code-critic.md
@@ -1,7 +1,7 @@
 ---
 name: code-critic
 description: "WHEN: PROACTIVELY after completing code changes (feature, refactor, architecture decision)—invoke WITHOUT waiting for user request. INPUT: File paths/directory to review, context about what changed and why. OUTPUT: Prioritized critical issues (correctness, security, over-engineering, systemic problems) with root causes and structural fixes—no style nitpicks."
-tools: Glob, Grep, Read, WebFetch, TodoWrite, WebSearch, BashOutput, KillShell
+tools: Glob, Grep, Read, Write, Bash, WebFetch, TodoWrite, WebSearch, BashOutput, KillShell
 model: opus
 color: purple
 skills:
@@ -27,9 +27,37 @@ The Core Principles below describe *how* to review once the precondition is met.
 
 ## Output Contract
 
-When the precondition is met, you return critical findings in the form **Issue / Root Cause / Impact / Fix**, ending with a **Priority Assessment**. The dispatched skills (`critic-design-review`, `critic-implementation-review`) define this format; you preserve it on output.
+When the precondition is met, you produce critical findings in the form **Issue / Root Cause / Impact / Fix**, ending with a **Priority Assessment**. The dispatched skills (`critic-design-review`, `critic-implementation-review`) define this format; you preserve it.
 
-**Callers must surface this output verbatim**—no summarization, no cherry-picking, no tone softening. The brutal-honest register is the value of the review; diluting it nullifies the work. Any caller routing your output through a paraphrasing or softening transformation is in violation of your output contract, and the defect is theirs, not yours.
+### Postcondition: persist the review before returning
+
+A review that exists only in the session message stream evaporates when the session ends. Every successful review **must be persisted to a file** before you return; the file path is part of your return value. This is a binding postcondition—violating it is a supplier-side bug.
+
+Steps (do them in this order, every time):
+
+1. **Resolve the workspace root**: run `Bash` with `pwd` (or `git rev-parse --show-toplevel` if inside a git repo) to obtain the absolute path. Use whichever the caller treats as the workspace root—prefer the git toplevel when available.
+2. **Ensure `<workspaceRootDir>/tmp/` exists**: `mkdir -p <workspaceRootDir>/tmp`.
+3. **Write the full findings** to `<workspaceRootDir>/tmp/code-critic-<ISO8601-utc-timestamp>.md` (e.g., `tmp/code-critic-20260507T125301Z.md`). Use the absolute path with the `Write` tool. Begin the file with a YAML front-matter block:
+
+   ```
+   ---
+   agent: code-critic
+   layer: design | implementation | both
+   created_at: <ISO8601 UTC>
+   target: <short identifier of what was reviewed>
+   intent: <one-line restatement of the change intent>
+   ---
+   ```
+
+   followed by the full findings body in the `Issue / Root Cause / Impact / Fix` + `Priority Assessment` form.
+
+4. **End your returned message with the absolute file path** on its own line, prefixed by `Review saved to: `. The findings body must also appear in the returned message itself (so the caller can surface it verbatim without re-reading the file)—the persisted file is the durable record, the inline body is the live channel.
+
+If any step fails (permission, disk, missing tools), return an error naming the step that failed; do not return findings without persistence. The postcondition is non-negotiable.
+
+### Verbatim surface rule for callers
+
+**Callers must surface the inline findings verbatim**—no summarization, no cherry-picking, no tone softening. The brutal-honest register is the value of the review; diluting it nullifies the work. Any caller routing your output through a paraphrasing or softening transformation is in violation of your output contract, and the defect is theirs, not yours. The persisted file is the secondary record; the live message is the primary surface.
 
 ## Core Principles
 

--- a/claude/agents/code-critic.md
+++ b/claude/agents/code-critic.md
@@ -59,6 +59,23 @@ If any step fails (permission, disk, missing tools), return an error naming the 
 
 **Callers must surface the inline findings verbatim**—no summarization, no cherry-picking, no tone softening. The brutal-honest register is the value of the review; diluting it nullifies the work. Any caller routing your output through a paraphrasing or softening transformation is in violation of your output contract, and the defect is theirs, not yours. The persisted file is the secondary record; the live message is the primary surface.
 
+## Prior Review Awareness
+
+The persisted files from your Output Contract are not write-only logs—they are **institutional memory** the next reviewer (you) must read. Before producing fresh findings, reconcile against prior reviews of the same context. Skipping this step lets the same defect get re-raised, re-debated, and re-deferred across cycles, and silently degrades the value of every review.
+
+Steps (perform after the precondition check, before applying the Core Principles below):
+
+1. **List**: enumerate `<workspaceRootDir>/tmp/code-critic-*.md` (via `Glob` or `Bash ls`).
+2. **Filter to relevant**: read each file's YAML front-matter and consider it relevant when its `target` overlaps the current target, its `intent` is related, and its `layer` is the same or adjacent. When in doubt, read.
+3. **Reconcile each prior issue against the current code**:
+   - **Resolved**: the structural fix has been applied. Do not re-raise as a finding. You may note it once under the Priority Assessment as "previously raised, now resolved" only if it informs current prioritization.
+   - **Persisted (unaddressed)**: re-raise it explicitly, and tag the issue heading with **`carried over from <prior file path>`**. The repetition is the point—a finding ignored across reviews is itself a defect signal that must surface louder, not quieter.
+   - **Partially addressed**: name the gap precisely. Do not accept a partial fix as resolution.
+   - **Regressed / re-introduced**: report as a fresh issue and link the prior file path that first identified it.
+4. **New issues** absent from prior reviews are reported as usual.
+
+If relevant prior files exist and you produce a review without checking them, you have shipped an incomplete review—the new findings have not been reconciled against history. That is itself a postcondition violation and a supplier-side bug.
+
 ## Core Principles
 
 **YAGNI (You Aren't Gonna Need It)**: Ruthlessly eliminate code built for hypothetical future requirements. Three similar lines are better than a premature abstraction. Helpers, utilities, and frameworks for one-time operations are waste. Current requirements only—nothing more.

--- a/claude/skills/call-code-critic/SKILL.md
+++ b/claude/skills/call-code-critic/SKILL.md
@@ -1,30 +1,30 @@
 ---
 name: call-code-critic
-description: "WHEN: the user wants to invoke the `code-critic` agent for a critical review of current code, a PR, or specific files (`/call-code-critic`). INPUT: review target (paths / diff / PR number / pasted code) + intent of the change + review layer in scope (`design` / `implementation` / `both` / `unspecified`). OUTPUT: launches the `code-critic` agent via the Agent tool and surfaces its critical findings to the user verbatim, preserving structure and tone."
+description: "WHEN: the user wants a critical review by the `code-critic` agent (`/call-code-critic`). OUTPUT: gathers the agent's required inputs from the user (review target, intent, layer), launches `code-critic` via the Agent tool, and surfaces the agent's critical findings to the user verbatim—preserving structure and tone."
 user-invocable: true
 ---
 
 ## Role
 
-This skill is the **entry point** for invoking the `code-critic` agent. The agent declares an Invocation Contract whose precondition is sufficient input from the caller—review target, intent of the change, review layer in scope. This skill exists solely to satisfy that precondition and dispatch the agent.
+This skill is the **entry point** for invoking the `code-critic` agent. The agent declares an Invocation Contract whose precondition is sufficient input from the caller. **The skill's job is to gather those inputs from the user and hand them to the agent.** It does not critique.
 
-All review logic—Review Layering, the foundational lenses (High Cohesion / Loose Coupling, Open-Closed Principle, Design by Contract, Secure by Design), Test Smell as Design Signal, the choice between `critic-design-review` and `critic-implementation-review`—lives **inside the agent**. This skill does not critique. It dispatches.
+All review logic—Review Layering, the foundational lenses (High Cohesion / Loose Coupling, Open-Closed Principle, Design by Contract, Secure by Design), Test Smell as Design Signal, the choice between `critic-design-review` and `critic-implementation-review`—lives **inside the agent**.
 
 ## Procedure
 
-### 1. Verify the Invocation Contract precondition
+### 1. Gather the agent's required inputs from the user
 
-The `code-critic` agent requires three inputs. If any are missing, **do not launch the agent.** Use `AskUserQuestion` to demand the missing items first; partial invocation will be refused by the agent's own Invocation Contract.
+The `code-critic` agent's Invocation Contract requires three items. If the user's invocation already supplies all three (e.g., "review the diff on this branch as a design change for the new auth module"), proceed. If anything is missing, demand it via `AskUserQuestion` before launching the agent—do not guess, do not let the agent fill in gaps. Bypassing this relocates a caller-side defect to the supplier.
 
 - **Review target**: file paths, directory, diff, PR number, or pasted code—each in identifiable scope
 - **Intent of the change**: what the change is supposed to accomplish; for design review, the design intent and the constraints driving the shape; for implementation review, the contract / signature / invariants the implementation must satisfy
 - **Layer in scope**: `design` / `implementation` / `both` / `unspecified` (when `unspecified`, the agent decides via Review Layering—if the change touches both layers, design review runs first)
 
-Do not assume the agent will "figure out" missing inputs. Demanding them up front is the contract; bypassing it relocates a caller-side defect to the supplier.
+When in doubt about layer, pass `unspecified` rather than guessing—the agent's Review Layering will route correctly.
 
 ### 2. Launch `code-critic` via the Agent tool
 
-Call the `Agent` tool with `subagent_type: code-critic`. Embed the three precondition items in the prompt with this structure:
+Call the `Agent` tool with `subagent_type: code-critic`. Pass the three gathered items in the prompt with this structure:
 
 ```
 ## Review target
@@ -46,7 +46,7 @@ The agent returns critical findings in the form `Issue` / `Root Cause` / `Impact
 
 ## Constraints
 
-- The skill **only dispatches**. Do not generate critique content inside this skill.
+- The skill **only gathers inputs and dispatches**. Do not generate critique content inside this skill.
 - Do not launch the agent without the three precondition items satisfied. Partial invocation is refused by the agent.
 - Do not paraphrase, summarize, or soften the agent's findings before presenting them.
 - Do not pre-decide the review layer when it is genuinely unclear; pass `unspecified` and let the agent's Review Layering route correctly.

--- a/claude/skills/call-code-critic/SKILL.md
+++ b/claude/skills/call-code-critic/SKILL.md
@@ -1,52 +1,44 @@
 ---
 name: call-code-critic
-description: "WHEN: the user wants a critical review by the `code-critic` agent (`/call-code-critic`). OUTPUT: gathers the agent's required inputs from the user (review target, intent, layer), launches `code-critic` via the Agent tool, and surfaces the agent's critical findings to the user verbatim—preserving structure and tone."
+description: "WHEN: the user wants a critical review by the `code-critic` agent. The skill gathers the agent's required Invocation Contract inputs (review target, intent, layer) from the user and dispatches the agent via the Agent tool."
 user-invocable: true
 ---
 
 ## Role
 
-This skill is the **entry point** for invoking the `code-critic` agent. The agent declares an Invocation Contract whose precondition is sufficient input from the caller. **The skill's job is to gather those inputs from the user and hand them to the agent.** It does not critique.
+This skill is the **entry seam** between the user and the `code-critic` agent. Its responsibility is narrow: gather the three Invocation Contract inputs the agent requires, then dispatch the agent. Nothing more.
 
-All review logic—Review Layering, the foundational lenses (High Cohesion / Loose Coupling, Open-Closed Principle, Design by Contract, Secure by Design), Test Smell as Design Signal, the choice between `critic-design-review` and `critic-implementation-review`—lives **inside the agent**.
+All review logic—Review Layering, the foundational lenses (High Cohesion / Loose Coupling, Open-Closed Principle, Design by Contract, Secure by Design), Test Smell as Design Signal, the choice between `critic-design-review` and `critic-implementation-review`—lives **inside the agent**. The agent owns both its Invocation Contract (input shape) and its output contract (findings shape and the verbatim-surface rule). The skill only feeds it correctly-shaped input.
 
 ## Procedure
 
 ### 1. Gather the agent's required inputs from the user
 
-The `code-critic` agent's Invocation Contract requires three items. If the user's invocation already supplies all three (e.g., "review the diff on this branch as a design change for the new auth module"), proceed. If anything is missing, demand it via `AskUserQuestion` before launching the agent—do not guess, do not let the agent fill in gaps. Bypassing this relocates a caller-side defect to the supplier.
+The agent's Invocation Contract requires three items. If the user's invocation already supplies them all (e.g., "review the diff on this branch as a design change for the new auth module"), proceed. If anything is missing, gather it via `AskUserQuestion` before launching—best-effort fill at the entry seam so the agent does not have to refuse and round-trip:
 
-- **Review target**: file paths, directory, diff, PR number, or pasted code—each in identifiable scope
+- **Code under review**: file paths, directory, diff, PR number, or pasted code—each in identifiable scope
 - **Intent of the change**: what the change is supposed to accomplish; for design review, the design intent and the constraints driving the shape; for implementation review, the contract / signature / invariants the implementation must satisfy
-- **Layer in scope**: `design` / `implementation` / `both` / `unspecified` (when `unspecified`, the agent decides via Review Layering—if the change touches both layers, design review runs first)
-
-When in doubt about layer, pass `unspecified` rather than guessing—the agent's Review Layering will route correctly.
+- **Review layer in scope**: `design` / `implementation` / `both` / `unspecified`
 
 ### 2. Launch `code-critic` via the Agent tool
 
-Call the `Agent` tool with `subagent_type: code-critic`. Pass the three gathered items in the prompt with this structure:
+Call the `Agent` tool with `subagent_type: code-critic`. Pass the three gathered items in this structure (headings match the agent's Invocation Contract terms verbatim):
 
 ```
-## Review target
+## Code under review
 <file paths / diff / PR number / pasted code, with identifiable scope>
 
 ## Intent of the change
 <what the change accomplishes; for design review, the design intent and constraints;
  for implementation review, the contract / signature / invariants to satisfy>
 
-## Layer in scope
+## Review layer in scope
 design | implementation | both | unspecified
 ```
 
 Pass a short, identifying `description` such as `Critical review via code-critic`.
 
-### 3. Surface the agent's output verbatim
-
-The agent returns critical findings in the form `Issue` / `Root Cause` / `Impact` / `Fix`, ending with a `Priority Assessment`. Present this output **as-is**: no summarization, no cherry-picking, no tone softening. The agent's brutal-honest register is the value—do not dilute it.
-
 ## Constraints
 
-- The skill **only gathers inputs and dispatches**. Do not generate critique content inside this skill.
-- Do not launch the agent without the three precondition items satisfied. Partial invocation is refused by the agent.
-- Do not paraphrase, summarize, or soften the agent's findings before presenting them.
-- Do not pre-decide the review layer when it is genuinely unclear; pass `unspecified` and let the agent's Review Layering route correctly.
+- The skill **only gathers and dispatches**. It does not critique, route between design/implementation, or shape the agent's output.
+- Best-effort gather at the seam; the **authoritative precondition enforcement is the agent's**. If a malformed call slips through, the agent's Invocation Contract will refuse it.

--- a/claude/skills/call-code-critic/SKILL.md
+++ b/claude/skills/call-code-critic/SKILL.md
@@ -1,52 +1,52 @@
 ---
 name: call-code-critic
-description: "WHEN: ユーザーが現在のコード変更・PR・ファイルに対して code-critic agent による批判的レビューを起動したいとき。`/call-code-critic` で呼ぶ。INPUT: レビュー対象 (コードのパス / diff / PR番号 等) + 変更意図 + レビュー対象レイヤー (design / implementation / both / unspecified)。OUTPUT: code-critic agent を Agent ツールで起動し、返ってきた critical findings を構造のまま提示。"
+description: "WHEN: the user wants to invoke the `code-critic` agent for a critical review of current code, a PR, or specific files (`/call-code-critic`). INPUT: review target (paths / diff / PR number / pasted code) + intent of the change + review layer in scope (`design` / `implementation` / `both` / `unspecified`). OUTPUT: launches the `code-critic` agent via the Agent tool and surfaces its critical findings to the user verbatim, preserving structure and tone."
 user-invocable: true
 ---
 
-## 役割
+## Role
 
-`code-critic` agent を起動するための **エントリポイント**。`code-critic` は Invocation Contract により precondition（レビュー対象コード / 変更意図 / レビュー対象レイヤー）を要求する。本 skill はその precondition を満たした形で agent を呼び出すことだけに責務を持つ。
+This skill is the **entry point** for invoking the `code-critic` agent. The agent declares an Invocation Contract whose precondition is sufficient input from the caller—review target, intent of the change, review layer in scope. This skill exists solely to satisfy that precondition and dispatch the agent.
 
-レビューロジック（Review Layering、High Cohesion / Loose Coupling、OCP、DbC、SbD、Test Smell as Design Signal、`critic-design-review` / `critic-implementation-review` の使い分け）は **すべて agent 側** にある。本 skill は判断しない。
+All review logic—Review Layering, the foundational lenses (High Cohesion / Loose Coupling, Open-Closed Principle, Design by Contract, Secure by Design), Test Smell as Design Signal, the choice between `critic-design-review` and `critic-implementation-review`—lives **inside the agent**. This skill does not critique. It dispatches.
 
-## 手順
+## Procedure
 
-### 1. precondition の充足を確認
+### 1. Verify the Invocation Contract precondition
 
-`code-critic` の Invocation Contract に従い、以下3点が揃っているか確認する。揃っていなければ **agent を起動せず**、`AskUserQuestion` で不足項目を要求してから進む（partial invocation は agent 側でも refuse される）。
+The `code-critic` agent requires three inputs. If any are missing, **do not launch the agent.** Use `AskUserQuestion` to demand the missing items first; partial invocation will be refused by the agent's own Invocation Contract.
 
-- **レビュー対象**: ファイルパス / ディレクトリ / diff / PR 番号 / 貼り付けコードのいずれか、識別可能なスコープ付き
-- **変更意図**: この変更が何を達成しようとしているか。design review なら設計意図と制約、implementation review なら実装が満たすべき contract / signature / invariants
-- **レビュー対象レイヤー**: `design` / `implementation` / `both` / `unspecified` のいずれか。`unspecified` の場合、agent が Review Layering で判断する（両方触るなら design review 先行）
+- **Review target**: file paths, directory, diff, PR number, or pasted code—each in identifiable scope
+- **Intent of the change**: what the change is supposed to accomplish; for design review, the design intent and the constraints driving the shape; for implementation review, the contract / signature / invariants the implementation must satisfy
+- **Layer in scope**: `design` / `implementation` / `both` / `unspecified` (when `unspecified`, the agent decides via Review Layering—if the change touches both layers, design review runs first)
 
-precondition が揃わないまま agent を起動するな。「足りない部分は agent が自分で判断する」と推定して起動するのは Invocation Contract 違反。
+Do not assume the agent will "figure out" missing inputs. Demanding them up front is the contract; bypassing it relocates a caller-side defect to the supplier.
 
-### 2. Agent ツールで code-critic を起動
+### 2. Launch `code-critic` via the Agent tool
 
-`Agent` ツールを `subagent_type: code-critic` で呼び出す。プロンプトには precondition の3項目を以下の構造で含める:
+Call the `Agent` tool with `subagent_type: code-critic`. Embed the three precondition items in the prompt with this structure:
 
 ```
 ## Review target
-<file paths / diff / PR number / pasted code、識別可能なスコープ>
+<file paths / diff / PR number / pasted code, with identifiable scope>
 
 ## Intent of the change
-<変更が何を達成しようとしているか。design review なら設計意図と制約、
- implementation review なら満たすべき contract / signature / invariants>
+<what the change accomplishes; for design review, the design intent and constraints;
+ for implementation review, the contract / signature / invariants to satisfy>
 
 ## Layer in scope
 design | implementation | both | unspecified
 ```
 
-`description` には `Critical review via code-critic` 等、タスクが識別可能な短い文字列を渡す。
+Pass a short, identifying `description` such as `Critical review via code-critic`.
 
-### 3. agent の出力をそのまま提示
+### 3. Surface the agent's output verbatim
 
-agent が返す critical findings（`Issue` / `Root Cause` / `Impact` / `Fix` の構造と末尾の `Priority Assessment`）は **要約・取捨選択・トーン緩和をせず**、構造を保ったままユーザーに提示する。`code-critic` の brutal-honest トーンを薄めない。
+The agent returns critical findings in the form `Issue` / `Root Cause` / `Impact` / `Fix`, ending with a `Priority Assessment`. Present this output **as-is**: no summarization, no cherry-picking, no tone softening. The agent's brutal-honest register is the value—do not dilute it.
 
-## 制約
+## Constraints
 
-- 本 skill は **agent を起動するだけ** が責務。critique 内容を skill 内で生成するな
-- precondition が不足したまま agent を起動するな。partial invocation は agent の Invocation Contract に refuse される
-- agent の出力を「やわらかく」言い換えるな
-- レビュー対象レイヤーの判断を skill 内で勝手に決めるな。`unspecified` で渡し、agent の Review Layering に委ねるのが既定
+- The skill **only dispatches**. Do not generate critique content inside this skill.
+- Do not launch the agent without the three precondition items satisfied. Partial invocation is refused by the agent.
+- Do not paraphrase, summarize, or soften the agent's findings before presenting them.
+- Do not pre-decide the review layer when it is genuinely unclear; pass `unspecified` and let the agent's Review Layering route correctly.

--- a/claude/skills/call-code-critic/SKILL.md
+++ b/claude/skills/call-code-critic/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: call-code-critic
+description: "WHEN: ユーザーが現在のコード変更・PR・ファイルに対して code-critic agent による批判的レビューを起動したいとき。`/call-code-critic` で呼ぶ。INPUT: レビュー対象 (コードのパス / diff / PR番号 等) + 変更意図 + レビュー対象レイヤー (design / implementation / both / unspecified)。OUTPUT: code-critic agent を Agent ツールで起動し、返ってきた critical findings を構造のまま提示。"
+user-invocable: true
+---
+
+## 役割
+
+`code-critic` agent を起動するための **エントリポイント**。`code-critic` は Invocation Contract により precondition（レビュー対象コード / 変更意図 / レビュー対象レイヤー）を要求する。本 skill はその precondition を満たした形で agent を呼び出すことだけに責務を持つ。
+
+レビューロジック（Review Layering、High Cohesion / Loose Coupling、OCP、DbC、SbD、Test Smell as Design Signal、`critic-design-review` / `critic-implementation-review` の使い分け）は **すべて agent 側** にある。本 skill は判断しない。
+
+## 手順
+
+### 1. precondition の充足を確認
+
+`code-critic` の Invocation Contract に従い、以下3点が揃っているか確認する。揃っていなければ **agent を起動せず**、`AskUserQuestion` で不足項目を要求してから進む（partial invocation は agent 側でも refuse される）。
+
+- **レビュー対象**: ファイルパス / ディレクトリ / diff / PR 番号 / 貼り付けコードのいずれか、識別可能なスコープ付き
+- **変更意図**: この変更が何を達成しようとしているか。design review なら設計意図と制約、implementation review なら実装が満たすべき contract / signature / invariants
+- **レビュー対象レイヤー**: `design` / `implementation` / `both` / `unspecified` のいずれか。`unspecified` の場合、agent が Review Layering で判断する（両方触るなら design review 先行）
+
+precondition が揃わないまま agent を起動するな。「足りない部分は agent が自分で判断する」と推定して起動するのは Invocation Contract 違反。
+
+### 2. Agent ツールで code-critic を起動
+
+`Agent` ツールを `subagent_type: code-critic` で呼び出す。プロンプトには precondition の3項目を以下の構造で含める:
+
+```
+## Review target
+<file paths / diff / PR number / pasted code、識別可能なスコープ>
+
+## Intent of the change
+<変更が何を達成しようとしているか。design review なら設計意図と制約、
+ implementation review なら満たすべき contract / signature / invariants>
+
+## Layer in scope
+design | implementation | both | unspecified
+```
+
+`description` には `Critical review via code-critic` 等、タスクが識別可能な短い文字列を渡す。
+
+### 3. agent の出力をそのまま提示
+
+agent が返す critical findings（`Issue` / `Root Cause` / `Impact` / `Fix` の構造と末尾の `Priority Assessment`）は **要約・取捨選択・トーン緩和をせず**、構造を保ったままユーザーに提示する。`code-critic` の brutal-honest トーンを薄めない。
+
+## 制約
+
+- 本 skill は **agent を起動するだけ** が責務。critique 内容を skill 内で生成するな
+- precondition が不足したまま agent を起動するな。partial invocation は agent の Invocation Contract に refuse される
+- agent の出力を「やわらかく」言い換えるな
+- レビュー対象レイヤーの判断を skill 内で勝手に決めるな。`unspecified` で渡し、agent の Review Layering に委ねるのが既定


### PR DESCRIPTION
## Summary
- Add a user-invocable entry-point skill (\`call-code-critic\`) for launching the \`code-critic\` agent
- The skill is the **entry seam**: it gathers the agent's three Invocation Contract inputs (code under review, intent, review layer) from the user and dispatches the agent—nothing more
- Review logic stays inside the agent; output shaping (verbatim surface rule, persistence) is owned by the agent's new **Output Contract** section
- **Persistence postcondition** (Output Contract): every successful review is written to \`<workspaceRootDir>/tmp/code-critic-<branch-slug>-<rev>.md\` (3-digit per-branch revision, e.g. \`code-critic-feat-call-code-critic-skill-003.md\`) with YAML front-matter (\`agent\` / \`layer\` / \`branch\` / \`revision\` / \`created_at\` / \`target\` / \`intent\`). Branch is the natural context boundary; revision counts within a branch. The returned message ends with \`Review saved to: <absolute path>\`. Reviews no longer evaporate at session end. Agent \`tools\` extended with \`Write\` and \`Bash\`
- **Prior Review Awareness** (new section): on every invocation the agent enumerates \`<workspaceRootDir>/tmp/code-critic-<branch-slug>-*.md\` for the **current branch only**, filters to relevant prior reviews via front-matter, and reconciles each prior issue against the current code (Resolved / Persisted / Partially addressed / Regressed / New). Persisted issues are re-raised with a \`carried over from <prior file path>\` tag. Skipping the reconciliation when relevant prior files exist is itself a postcondition violation
- Self-reviewed via \`code-critic\` and the must-fix / follow-up findings (responsibility split, precondition ownership, slash-command leakage in description, template label drift, layer-guidance leakage) have been applied

## Test plan
- [ ] When the user invokes the skill with a complete request, the agent is launched directly without questions
- [ ] When precondition items are missing, \`AskUserQuestion\` gathers them before launching (best-effort)
- [ ] When the layer is genuinely ambiguous, \`unspecified\` is passed and the agent's Review Layering routes correctly
- [ ] The agent's findings reach the user in their declared \`Issue / Root Cause / Impact / Fix\` + \`Priority Assessment\` form, unaltered (Output Contract verbatim rule on callers)
- [ ] First review on a branch produces \`tmp/code-critic-<branch-slug>-001.md\`; the next review on the same branch produces \`-002.md\`, etc.
- [ ] Reviews on a different branch start their own \`-001.md\` counter and do not appear in the current branch's Prior Review Awareness scan
- [ ] Persisted issues from prior in-branch reviews are re-raised with \`carried over from <path>\`; resolved issues are not re-raised; partial fixes are flagged as gaps; regressions are flagged as fresh issues citing the prior file