### PR TITLE
feat(call-code-critic): mandate address-then-re-review iteration loop

### DIFF
--- a/claude/skills/call-code-critic/SKILL.md
+++ b/claude/skills/call-code-critic/SKILL.md
@@ -1,14 +1,17 @@
 ---
 name: call-code-critic
-description: "WHEN: the user wants a critical review by the `code-critic` agent. The skill gathers the agent's required Invocation Contract inputs (review target, intent, layer) from the user and dispatches the agent via the Agent tool."
+description: "WHEN: the user wants a critical review by the `code-critic` agent. The skill gathers the agent's required Invocation Contract inputs (review target, intent, layer), dispatches the agent via the Agent tool, and drives the **address-then-re-review** loop until no actionable findings remain or the user explicitly defers what is left."
 user-invocable: true
 ---
 
 ## Role
 
-This skill is the **entry seam** between the user and the `code-critic` agent. Its responsibility is narrow: gather the three Invocation Contract inputs the agent requires, then dispatch the agent. Nothing more.
+This skill is the **entry seam** between the user and the `code-critic` agent, **and it owns the review iteration loop**. Its responsibility is twofold:
 
-All review logic—Review Layering, the foundational lenses (High Cohesion / Loose Coupling, Open-Closed Principle, Design by Contract, Secure by Design), Test Smell as Design Signal, the choice between `critic-design-review` and `critic-implementation-review`—lives **inside the agent**. The agent owns both its Invocation Contract (input shape) and its output contract (findings shape and the verbatim-surface rule). The skill only feeds it correctly-shaped input.
+1. Gather the three Invocation Contract inputs the agent requires, then dispatch the agent.
+2. Drive the **address-then-re-review** loop after each dispatch, until the agent returns no actionable findings or the user explicitly defers what remains. A single invocation is **not** a complete review—it is a single iteration.
+
+All review logic—Review Layering, the foundational lenses (High Cohesion / Loose Coupling, Open-Closed Principle, Design by Contract, Secure by Design), Test Smell as Design Signal, the choice between `critic-design-review` and `critic-implementation-review`—lives **inside the agent**. The skill never critiques. But the skill *does* own the cycle, because findings without follow-through are wasted output.
 
 ## Procedure
 
@@ -38,7 +41,32 @@ design | implementation | both | unspecified
 
 Pass a short, identifying `description` such as `Critical review via code-critic`.
 
+### 3. Drive the address-then-re-review loop (mandatory)
+
+The agent's first response is **never the end**. Iterate the cycle below until the termination condition is met. The loop is **non-negotiable**: a review that is not acted upon is the same as no review.
+
+For each iteration:
+
+1. **Surface the agent's findings to the user verbatim** (Output Contract: `Issue / Root Cause / Impact / Fix` + `Priority Assessment`). Note the persisted file path returned by the agent (`Review saved to: <path>`).
+2. **Triage with the user** for each finding using `AskUserQuestion`:
+   - **Address now**: apply the structural fix the agent prescribed (not just a textual patch—the `Fix` text is the structural target). Commit if appropriate.
+   - **Defer (with reason)**: only if the user explicitly accepts the deferral. The issue stays in the persisted file; the next review's Prior Review Awareness will carry it over.
+   - **Reject (with reason)**: rare. Only when the user gives a domain reason that makes the finding non-applicable. Record the reasoning so the next review reconciles correctly and does not re-raise it as a persisted issue.
+3. **Apply the addressed fixes** to the code under review.
+4. **Re-launch `code-critic`** (return to step 2 of this Procedure) with the same Invocation Contract shape, but update the `Intent of the change` to reflect the iteration—e.g., append: `Iteration N+1: addresses findings from <prior file path>`. The agent's Prior Review Awareness will reconcile against the persisted file and decide what is Resolved / Persisted / Partially addressed / Regressed.
+
+**Termination condition** (loop exits only when **all three** hold):
+
+- The agent returns **no new must-fix findings** in the current iteration.
+- The agent reports **no persisted (carried-over) findings**, or every persisted finding has a recorded user decision (Defer / Reject) from a prior iteration.
+- The user has explicitly accepted any remaining lower-priority items as out of scope.
+
+When the loop exits, summarize the final state to the user: which iterations ran, which findings were addressed in code, which were deferred (with reasons), which were rejected (with reasons), and the path of the latest persisted review.
+
 ## Constraints
 
-- The skill **only gathers and dispatches**. It does not critique, route between design/implementation, or shape the agent's output.
-- Best-effort gather at the seam; the **authoritative precondition enforcement is the agent's**. If a malformed call slips through, the agent's Invocation Contract will refuse it.
+- The skill **gathers, dispatches, and drives the iteration loop**. It does not critique, route between design/implementation, or shape the agent's output.
+- Best-effort precondition gather at the seam; the **authoritative precondition enforcement is the agent's**. If a malformed call slips through, the agent's Invocation Contract will refuse it.
+- A single invocation is **not** a complete review. Exiting after one pass without a recorded user decision on the findings is a contract violation of this skill.
+- The user owns the Address / Defer / Reject decision for each finding. Do not auto-defer or auto-reject; ask via `AskUserQuestion`.
+- Apply structural fixes (per the agent's `Fix` text), not surface-level textual patches that leave the root cause intact.

--- a/claude/skills/call-code-critic/SKILL.md
+++ b/claude/skills/call-code-critic/SKILL.md
@@ -23,7 +23,7 @@ The agent's Invocation Contract requires three items. If the user's invocation a
 - **Intent of the change**: what the change is supposed to accomplish; for design review, the design intent and the constraints driving the shape; for implementation review, the contract / signature / invariants the implementation must satisfy
 - **Review layer in scope**: `design` / `implementation` / `both` / `unspecified`
 
-### 2. Launch `code-critic` via the Agent tool
+### 2. Launch `code-critic` for the initial iteration
 
 Call the `Agent` tool with `subagent_type: code-critic`. Pass the three gathered items in this structure (headings match the agent's Invocation Contract terms verbatim):
 
@@ -39,7 +39,9 @@ Call the `Agent` tool with `subagent_type: code-critic`. Pass the three gathered
 design | implementation | both | unspecified
 ```
 
-Pass a short, identifying `description` such as `Critical review via code-critic`.
+Pass a short, identifying `description` such as `Critical review via code-critic`. You may also pass a `name` such as `code-critic-<branch-slug>` so the agent is addressable by stable name in addition to the runtime-assigned ID.
+
+**Capture the agent's ID** from the response. The runtime emits it both as `agentId: <id>` and as a hint like `SendMessage with to: '<id>' to continue this agent`. This ID is the handle for every subsequent iteration in this loop—do not lose it. The conversation context inside that agent run is the one you must resume on every re-review.
 
 ### 3. Drive the address-then-re-review loop (mandatory)
 
@@ -53,7 +55,25 @@ For each iteration:
    - **Defer (with reason)**: only if the user explicitly accepts the deferral. The issue stays in the persisted file; the next review's Prior Review Awareness will carry it over.
    - **Reject (with reason)**: rare. Only when the user gives a domain reason that makes the finding non-applicable. Record the reasoning so the next review reconciles correctly and does not re-raise it as a persisted issue.
 3. **Apply the addressed fixes** to the code under review.
-4. **Re-launch `code-critic`** (return to step 2 of this Procedure) with the same Invocation Contract shape, but update the `Intent of the change` to reflect the iteration—e.g., append: `Iteration N+1: addresses findings from <prior file path>`. The agent's Prior Review Awareness will reconcile against the persisted file and decide what is Resolved / Persisted / Partially addressed / Regressed.
+4. **Re-review via `SendMessage` against the captured agent ID**—do **not** re-launch a fresh `Agent` for each iteration. Resuming the same agent keeps the prior findings, the persisted file paths, and the in-conversation discussion in its working memory; re-launching loses all of that and forces the agent to rebuild context from the persisted file alone. Continuity of the agent's working memory is the value of holding the ID.
+
+   Call `SendMessage` with `to: '<captured agent ID>'`. The message body focuses on the **delta**, since the agent already knows what was reviewed and what it raised:
+
+   ```
+   ## Iteration N+1: addresses findings from <prior file path>
+
+   ## Changes since prior review
+   <what was changed in the code; diff, paths, or summary referencing the prior issues>
+
+   ## User decisions on prior findings
+   - <prior issue title> → Address (fix applied as: <one-line summary>)
+   - <prior issue title> → Defer (reason: <user-supplied reason>)
+   - <prior issue title> → Reject (reason: <user-supplied reason; agent should not re-raise>)
+   ```
+
+   The agent runs another iteration—reconciles via Prior Review Awareness, applies Core Principles to the delta, and persists a fresh `code-critic-<branch-slug>-<rev+1>.md`. Surface the new findings (return to step 1 of this loop).
+
+   **Fallback**: if the agent ID is unavailable (e.g., the runtime no longer accepts `SendMessage` to it), launch a fresh `Agent` as in step 2 of this Procedure, but expand the `Intent of the change` to include the iteration number and the prior file path. Prior Review Awareness will still reconcile via the persisted files, but the in-conversation memory of the prior pass is lost—accept this only as a fallback.
 
 **Termination condition** (loop exits only when **all three** hold):
 
@@ -70,3 +90,4 @@ When the loop exits, summarize the final state to the user: which iterations ran
 - A single invocation is **not** a complete review. Exiting after one pass without a recorded user decision on the findings is a contract violation of this skill.
 - The user owns the Address / Defer / Reject decision for each finding. Do not auto-defer or auto-reject; ask via `AskUserQuestion`.
 - Apply structural fixes (per the agent's `Fix` text), not surface-level textual patches that leave the root cause intact.
+- **Capture the initial agent ID** and use `SendMessage` to that ID for every re-review in the loop. Re-launching a fresh `Agent` per iteration discards the agent's working memory of the prior pass and is wasteful; only fall back to a fresh launch if the captured ID is no longer addressable.


### PR DESCRIPTION
## Summary
\`call-code-critic\` を「一回呼び出して終わり」のワークフローから、**findings → triage → 対応 → 再レビュー** を必須サイクルとして駆動するワークフローに変更する。findings without follow-through は無価値であり、レビューを単発で打ち切ること自体が contract violation として扱う。

### Skill の責務拡張
- 既存: precondition の gather + agent dispatch (entry seam)
- 追加: イテレーションループの所有
- 追加: 初回 \`Agent\` 起動時の \`agentId\` 捕捉と、再レビュー時の \`SendMessage\` による同一 agent への継続依頼

### イテレーションループ
各回ごとに:
1. agent からの findings を verbatim 提示 (Output Contract に従う)
2. 各 finding を **Address / Defer / Reject** で \`AskUserQuestion\` で triage（auto 判定禁止、ユーザーが意思決定の所有者）
3. Address なら agent の \`Fix\` を構造的修正として適用
4. **\`SendMessage(to: <captured agent ID>)\` で再レビューを依頼** — fresh \`Agent\` 起動はしない。同一 agent の in-conversation working memory（前回 findings、persisted file path、議論の流れ）を継承させる。message body は delta（changes since prior review + user decisions on prior findings）に絞る
5. 終了条件 (3 つ全て満たすまでループ):
   - 新規 must-fix なし
   - persisted (carried-over) finding が無いか、全て Defer/Reject 済み
   - 残った lower-priority がユーザー明示で deferred

agent ID が無効化された場合のみ fresh \`Agent\` 起動にフォールバック、Prior Review Awareness が persisted file 経由で reconcile。

## Test plan
- [ ] 初回レビューで findings が出たとき、skill が triage を求めず終了することがない
- [ ] 全 finding に対し Address / Defer / Reject が user 経由で必ず決定される
- [ ] Address されたら fix を適用し、\`SendMessage\` で同 agent に delta を渡して再レビューが発火する
- [ ] persisted finding が次イテレーションで \`carried over from <path>\` として再掲される
- [ ] 終了条件 3 つ全てが満たされたときのみループが exit する
- [ ] agent ID が失われた場合は fresh \`Agent\` 起動にフォールバックし、Prior Review Awareness 経由で reconcile が継続する