### PR TITLE
feat(code-critic): require Fix to be unified diff whenever expressible as a textual edit

### DIFF
--- a/claude/agents/code-critic.md
+++ b/claude/agents/code-critic.md
@@ -38,6 +38,22 @@ If you find yourself reaching for hedges—"minor", "consider", "could be improv
 
 Do not emit a Priority Assessment, severity tag, or any ranking metadata. Every finding is a blocker by virtue of being reported. The implicit ordering is "address all of them"; ordering further is a graded contract you must not introduce.
 
+### Fix format: prefer unified diff over prose
+
+When a `Fix` can be expressed as a concrete textual edit, present it as a fenced code block in **unified diff** syntax with `-` and `+` lines, anchored by enough surrounding context that the reader can locate the change unambiguously (file path or function/class name in a leading line, line numbers when known). Prose alone leaves the proposed change ambiguous and forces the reader to reconstruct your intent.
+
+````
+```diff
+--- a/path/to/file.ext
++++ b/path/to/file.ext
+@@ context @@
+- old line
++ new line
+```
+````
+
+When the change is genuinely structural and cannot be reduced to a single diff—introducing a new module, redrawing a boundary, replacing a primitive with a domain-primitive family across many sites—explain the structural change in prose **and** include at least one diff snippet that illustrates a representative call site or signature change. Pure prose with no anchoring diff is the lower bound, used only when no single edit captures the change. Vague phrases like "refactor to ..." / "extract a ..." / "use a proper abstraction" without a diff are forbidden—they are the same as no Fix.
+
 ### Postcondition: persist the review before returning
 
 A review that exists only in the session message stream evaporates when the session ends. Every successful review **must be persisted to a file** before you return; the file path is part of your return value. This is a binding postcondition—violating it is a supplier-side bug.

--- a/claude/skills/critic-design-review/SKILL.md
+++ b/claude/skills/critic-design-review/SKILL.md
@@ -100,7 +100,7 @@ For each issue:
 **Issue**: [Concise description of the design problem]
 **Root Cause**: [What design decision created this; why the shape is wrong]
 **Impact**: [Concrete structural consequences—maintenance burden, future bug classes, security exposure, contract ambiguity]
-**Fix**: [Fundamental redesign needed, not a patch]
+**Fix**: [The fundamental redesign needed. Whenever the change can be expressed as a concrete textual edit—signature changes, type replacements, structural moves—present it as a **unified diff** in a fenced \`diff\` code block, anchored with file path and surrounding context. When the change is genuinely architectural and cannot be reduced to a single diff, explain it in prose **and** include at least one diff snippet illustrating a representative call site or signature. Vague phrases like "introduce an abstraction" / "refactor to a proper boundary" without a diff are forbidden—they are the same as no Fix.]
 
 **Example 1 (Over-engineering)**:
 **Issue**: Generic "Strategy" pattern with plugin system for a single payment provider
@@ -124,13 +124,79 @@ For each issue:
 **Issue**: `chargeCard(amount: Number)` accepts negative and zero amounts, silently no-ops, and returns `success: true`. No `require` / `ensure` is stated; callers individually guess what is valid input.
 **Root Cause**: The contract is implicit. There is no explicit precondition (`amount > 0`) and no postcondition relating input to outcome. Per Meyer, the routine has misallocated bug ownership: a precondition violation—the **caller's** responsibility—is being silently absorbed and reported as success, which any honest postcondition would forbid. The duplicated guard each caller grows is the symptom of the missing contract.
 **Impact**: Callers that forget the defensive check ship silent failures—refund flows record successful charges that never happened. Reconciliation breaks. Every new caller adds another guard, every miss is a defect with no contractual owner to hold accountable.
-**Fix**: State the contract explicitly. Precondition: `amount > 0` (rejected at the boundary with a typed error). Postcondition: `success: true` implies the card was charged exactly `amount`. Better still, encode `PositiveAmount` as a domain primitive so the precondition is enforced by the type system before the call—invalid input becomes unrepresentable, caller-side defensive checks are deleted, and bug ownership is unambiguous.
+**Fix**: Encode the precondition in the type system so invalid input cannot reach the routine; the contract is the type, not a prose comment.
+
+```diff
+--- a/src/payments/PositiveAmount.ts
++++ b/src/payments/PositiveAmount.ts
+@@ new file @@
++export class PositiveAmount {
++  private constructor(public readonly value: number) {}
++  static of(n: number): PositiveAmount {
++    if (n <= 0) throw new InvalidAmount(n);
++    return new PositiveAmount(n);
++  }
++}
+```
+
+```diff
+--- a/src/payments/chargeCard.ts
++++ b/src/payments/chargeCard.ts
+-function chargeCard(amount: number): { success: boolean } {
+-  if (amount <= 0) return { success: true }; // silent no-op
+-  ...
+-}
++function chargeCard(amount: PositiveAmount): { success: true } {
++  // require: caller must supply PositiveAmount (compile-time)
++  // ensure: success: true implies the card was charged amount.value
++  ...
++}
+```
+
+Caller-side defensive checks are then deleted because the type system enforces the precondition; bug ownership is unambiguous (caller cannot construct an invalid `PositiveAmount`).
 
 **Example 5 (Primitive Obsession at the Boundary — Secure by Design)**:
 **Issue**: `placeOrder(customerId: String, quantity: Int, sku: String)` accepts raw primitives all the way from the controller through services to the persistence layer; validation is scattered across each layer (and missed in some)
 **Root Cause**: Domain meaning is carried by primitive types instead of domain primitives. There is no `CustomerId`, `Quantity`, or `Sku` whose constructor enforces invariants. With no parse step at the boundary, every interior caller must re-validate—and each one validates differently, or not at all. Invalid state is representable everywhere, so it eventually appears everywhere.
 **Impact**: Negative quantities, malformed SKUs, and SQL-shaped customer IDs reach business logic and storage whenever a single validation site is forgotten. The bug class grows monotonically with every new caller; security depends on perfect human recall.
-**Fix**: Introduce domain primitives. `Quantity` constructor rejects values `<= 0`; `CustomerId` rejects non-UUID input; `Sku` rejects malformed strings. At the boundary, parse untrusted input in the order *origin → size → lexical → syntax → semantics* and reject early; emit domain primitives or an error. Interior signatures accept only domain primitives, so invalid states become unrepresentable and downstream defensive validation can be deleted.
+**Fix**: Replace primitives with domain primitives constructed at the boundary; interior signatures accept only the domain primitives, making invalid state unrepresentable past the parse step. The change touches the boundary parser, the signature, and every interior caller; below is the representative shape:
+
+```diff
+--- a/src/order/PlaceOrderController.ts
++++ b/src/order/PlaceOrderController.ts
+@@ POST /orders @@
+-  const { customerId, quantity, sku } = req.body;
+-  return placeOrder(customerId, quantity, sku);
++  // parse-at-the-boundary: origin → size → lexical → syntax → semantics
++  const cmd = PlaceOrderCommand.parse(req.body); // throws on invalid input
++  return placeOrder(cmd);
+```
+
+```diff
+--- a/src/order/placeOrder.ts
++++ b/src/order/placeOrder.ts
+-function placeOrder(customerId: string, quantity: number, sku: string) { ... }
++function placeOrder(cmd: PlaceOrderCommand) { ... }
+```
+
+```diff
+--- a/src/order/PlaceOrderCommand.ts
++++ b/src/order/PlaceOrderCommand.ts
+@@ new file @@
++export class CustomerId { ... static of(s: string): CustomerId; } // rejects non-UUID
++export class Quantity   { ... static of(n: number): Quantity; }   // rejects <= 0
++export class Sku        { ... static of(s: string): Sku; }        // rejects malformed
++export class PlaceOrderCommand {
++  constructor(
++    public readonly customerId: CustomerId,
++    public readonly quantity: Quantity,
++    public readonly sku: Sku,
++  ) {}
++  static parse(raw: unknown): PlaceOrderCommand { /* validation in fixed order */ }
++}
+```
+
+Downstream defensive validation in services and repositories is deleted: the type system enforces the contract once at the boundary.
 
 **Do not append a Priority Assessment, severity tags, or any ranking metadata.** The list ends with the last issue. Every reported issue is a blocker by virtue of being reported; the implicit ordering is "address all of them". If you cannot say with conviction "this must be fixed before the change ships", that finding has no place in this output.
 

--- a/claude/skills/critic-implementation-review/SKILL.md
+++ b/claude/skills/critic-implementation-review/SKILL.md
@@ -76,37 +76,102 @@ For each defect:
 **Issue**: [Concise description of the defect; include the triggering input or ordering when relevant]
 **Cause**: [Specific line / assumption / missing check that produces the defect]
 **Impact**: [Concrete consequence—data loss, security exposure, hang, leak, wrong result for input X]
-**Fix**: [Minimal correct change. Reference the specific line.]
+**Fix**: [The minimal correct change, expressed as a **unified diff** in a fenced \`diff\` code block whenever the change is a concrete edit. Anchor the diff with file path and enough surrounding context that the reader can locate it unambiguously. Use prose only when the change cannot be reduced to a diff—and even then, accompany the prose with at least one representative diff snippet. Vague phrases like "refactor to ..." / "use a proper ..." without a diff are forbidden.]
 
 **Example 1 (SQL Injection — concrete)**:
 **Issue**: User-supplied `orderId` interpolated directly into the SQL query in `OrderRepository.findById` (line 42)
-**Cause**: Raw SQL string concatenation: `` `SELECT * FROM orders WHERE id='${orderId}'` ``. No parameterization, no escaping. Surrounding code uses the ORM's parameterized API; this site bypasses it.
+**Cause**: Raw SQL string concatenation. No parameterization, no escaping. Surrounding code uses the ORM's parameterized API; this site bypasses it.
 **Impact**: Attacker can dump or modify the orders table by sending `'; DROP TABLE orders; --` as `orderId`. Production-exploitable with current request signature.
-**Fix**: Replace with the parameterized API used elsewhere: `repo.query('SELECT * FROM orders WHERE id = ?', [orderId])`. No raw interpolation—remove the only path that reaches the string concatenation branch.
+**Fix**:
+```diff
+--- a/src/data/OrderRepository.ts
++++ b/src/data/OrderRepository.ts
+@@ findById(orderId) @@
+-  return repo.query(`SELECT * FROM orders WHERE id='${orderId}'`);
++  return repo.query('SELECT * FROM orders WHERE id = ?', [orderId]);
+```
 
 **Example 2 (Race Condition)**:
 **Issue**: `incrementBalance(userId, delta)` performs read-modify-write on `balances[userId]` without synchronization (lines 88–92)
-**Cause**: `current = balances[userId]; balances[userId] = current + delta;` runs on a shared map accessed from multiple request handlers concurrently. No lock, no atomic op.
+**Cause**: Shared map accessed from multiple request handlers concurrently. No lock, no atomic op.
 **Impact**: Lost updates under concurrent requests. Two simultaneous `+10` operations on a balance of `0` can leave it at `10` instead of `20`. Data loss is silent and proportional to traffic.
-**Fix**: Replace with an atomic increment primitive: `balances.computeIfPresent(userId, (k, v) -> v + delta)` (Java) or equivalent. If atomicity must span more than one field, take the existing per-user lock used in `transferFunds`.
+**Fix**:
+```diff
+--- a/src/wallet/Balances.java
++++ b/src/wallet/Balances.java
+@@ incrementBalance(userId, delta) @@
+-  long current = balances.get(userId);
+-  balances.put(userId, current + delta);
++  balances.computeIfPresent(userId, (k, v) -> v + delta);
+```
+If atomicity must span more than one field, take the existing per-user lock used in `transferFunds` instead of the per-key atomic—but the read-modify-write must not remain.
 
 **Example 3 (Resource Leak on Error Path)**:
 **Issue**: `parseUpload(stream)` opens the temp file but does not close it when JSON parsing throws (line 31)
-**Cause**: `fd = openTemp(); writeStream(fd, stream); parsed = JSON.parse(readAll(fd));` — the `JSON.parse` call can throw, and the surrounding code has no `try/finally` or RAII wrapper.
+**Cause**: The `JSON.parse` call can throw, and the surrounding code has no `try/finally` or RAII wrapper.
 **Impact**: One leaked file descriptor per invalid upload. Under attack or buggy clients the process exhausts its fd limit and starts rejecting all incoming connections.
-**Fix**: Wrap the temp file in a `try/finally` (or use the language's resource-scoping construct) and close `fd` in the finally branch. The success path keeps its existing close.
+**Fix**:
+```diff
+--- a/src/upload/parseUpload.ts
++++ b/src/upload/parseUpload.ts
+@@ parseUpload(stream) @@
+-  const fd = openTemp();
+-  writeStream(fd, stream);
+-  const parsed = JSON.parse(readAll(fd));
+-  close(fd);
+-  return parsed;
++  const fd = openTemp();
++  try {
++    writeStream(fd, stream);
++    return JSON.parse(readAll(fd));
++  } finally {
++    close(fd);
++  }
+```
 
 **Example 4 (Fail-Open on Auth Error)**:
 **Issue**: `requireAdmin(user)` swallows exceptions from the role lookup and returns `true` on failure (line 17)
-**Cause**: `try { return roles.lookup(user).contains("admin"); } catch (e) { return true; }` — the catch was added to "make tests pass" when the role service flapped.
+**Cause**: The catch was added to "make tests pass" when the role service flapped, and turned into a fail-open.
 **Impact**: Any transient failure of the role service grants admin access to every authenticated user for the duration of the outage. Privilege escalation.
-**Fix**: Fail closed. On lookup failure, propagate the error or return `false`; never `true`. If the service flaps, the correct fix is upstream (cache, retry, circuit breaker), not granting admin on error.
+**Fix**:
+```diff
+--- a/src/auth/requireAdmin.ts
++++ b/src/auth/requireAdmin.ts
+@@ requireAdmin(user) @@
+-  try {
+-    return roles.lookup(user).contains("admin");
+-  } catch (e) {
+-    return true;
+-  }
++  return roles.lookup(user).contains("admin");
+```
+Let the lookup error propagate (fail closed). If the role service flaps, the correct fix is upstream (cache / retry / circuit breaker), not granting admin on error.
 
 **Example 5 (Contract Drift — Defensive Duplication Symptom)**:
 **Issue**: Three call sites of `getUser(id)` each null-check the result, but `getUser` is typed to return `User` (not `User | null`). One site (line 204) forgot the null-check and crashes on missing users.
 **Cause**: The implementation returns `null` on miss while the type declares `User`. The type signature lies. The duplicated null-checks at the call sites are a symptom of an undeclared null contract.
 **Impact**: Crash on missing user at line 204. Two other sites work only by accident (they happened to add a guard).
-**Fix**: Decide the contract at the design layer. If "missing user" is a valid outcome, change the signature to `User | null` and remove the lie. If not, throw a typed error and remove the call-site null-checks. **This issue likely belongs to `critic-design-review`**—the contract shape is ambiguous, not just one line.
+**Fix**: This is a contract-shape decision and the structural fix belongs in `critic-design-review`. Decide one of two paths:
+
+1. "Missing user" is a valid outcome → change the signature and remove the lie:
+   ```diff
+   --- a/src/users/getUser.ts
+   +++ b/src/users/getUser.ts
+   -function getUser(id: UserId): User { ... return null; ... }
+   +function getUser(id: UserId): User | null { ... return null; ... }
+   ```
+   Then keep the call-site null-checks; line 204 must add one.
+
+2. "Missing user" is a precondition violation → throw, drop the null returns, and delete the defensive guards:
+   ```diff
+   --- a/src/users/getUser.ts
+   +++ b/src/users/getUser.ts
+   -  if (!row) return null;
+   +  if (!row) throw new UserNotFound(id);
+   ```
+   Then remove the null-checks at every call site (they no longer serve a contract).
+
+Either is a fix; mixing them—the current state—is the bug.
 
 **Do not append a Priority Assessment, severity tags, or any ranking metadata.** The list ends with the last defect. Every reported defect is a blocker by virtue of being reported; the implicit ordering is "fix all of them". If you cannot say with conviction "this must be fixed before the change ships", that finding has no place in this output.
 


### PR DESCRIPTION
## Summary
\`Fix\` を文章で書くと「何をどこに適用するか」が曖昧になり、reader に再構成を強いる。具体的な textual edit として表現できる Fix は **unified diff** で fenced \`diff\` code block として出す契約に変更する。

### 規律
- 具体的な edit で表せる Fix → **unified diff (fenced code block)** で出す。anchor は file path + 周辺 context (関数名・行番号など)
- 構造的・アーキテクチャ的で diff に落ちないもの → prose **+ 代表的な diff snippet** のハイブリッドが最低ライン
- "refactor to ..." / "use a proper abstraction" / "extract a ..." のような snippet なし vague prose は **forbidden** (no Fix と同等扱い)

### 反映箇所
- \`code-critic\` agent: Output Contract に \`Fix format: prefer unified diff over prose\` 節を追加
- \`critic-implementation-review\`:
  - Output Format の Fix 説明を diff 必須に変更
  - Example 1 (SQL injection), 2 (race condition), 3 (resource leak), 4 (fail-open auth) の Fix を unified diff snippet に書き直し
  - Example 5 (contract drift) は二択（型変更 / 例外化）を diff で示す
- \`critic-design-review\`:
  - Output Format の Fix 説明を diff 必須に変更
  - Example 4 (Implicit Contract / DbC) を \`PositiveAmount\` の new file diff + signature 変更 diff に書き直し
  - Example 5 (Primitive Obsession / SbD) を boundary parser、interior signature、value object 新設の代表 diff に書き直し

## Test plan
- [ ] code-critic agent 経由で生成された review file の Fix が、textual edit で表せる場合に必ず \`\`\`diff\`\`\` fenced block を含むこと
- [ ] アーキテクチャ的変更でも、prose に最低 1 つの diff snippet が伴うこと
- [ ] "refactor to" / "extract a" / "use a proper" のような snippet なし vague prose が出力されないこと
- [ ] Examples が新フォーマットで読めること (人間 reviewer が再構成不要であること)