### PR TITLE
chore: tidy settings.json layout and ignore node_modules

### DIFF
--- a/.gitignore_global
+++ b/.gitignore_global
@@ -1,4 +1,5 @@
 .DS_Store
+node_modules
 
 .claude/settings.local.json
 .claude/**/*.local.*

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -20,12 +20,8 @@
       "Bash(sh:*)",
       "Bash(for *)",
       "Bash(* &)",
-      "Bash(* echo \"---\" *)",
       "Bash(bash:*)",
-      "Bash(sed *)",
       "Bash(find * -exec *)",
-      "Bash(git -C:*)",
-      "Bash(gh api graphql:*)",
       "Bash(gh api -X PUT*)",
       "Bash(gh api -X POST*)",
       "Bash(gh api -X DELETE*)",
@@ -57,11 +53,24 @@
       "Bash(gh pr merge *)"
     ]
   },
+  "hooks": {
+    "PermissionRequest": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "terminal-notifier -message '承認待ちです' -title 'Claude Code' -activate \"${__CFBundleIdentifier:-com.apple.Terminal}\""
+          }
+        ]
+      }
+    ]
+  },
   "enabledPlugins": {
     "frontend-design@claude-plugins-official": true,
     "session-handover@lacolaco-plugins": true,
     "protect-main-branch@lacolaco-plugins": true,
-    "example-skills@anthropic-agent-skills": true
+    "example-skills@anthropic-agent-skills": true,
+    "retrospective@lacolaco-plugins": true
   },
   "extraKnownMarketplaces": {
     "lacolaco-plugins": {
@@ -76,18 +85,6 @@
         "repo": "anthropics/skills"
       }
     }
-  },
-  "hooks": {
-    "PermissionRequest": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "terminal-notifier -message '承認待ちです' -title 'Claude Code' -activate \"${__CFBundleIdentifier:-com.apple.Terminal}\""
-          }
-        ]
-      }
-    ]
   },
   "language": "Japanese",
   "alwaysThinkingEnabled": true,


### PR DESCRIPTION
## Summary
- claude/settings.json の `hooks` ブロックを `enabledPlugins` の前に移動して可読性を向上
- 不要になった permissions.deny エントリ (`Bash(* echo "---"*)`, `Bash(sed *)`, `Bash(git -C:*)`, `Bash(gh api graphql:*)`) を削除
- `retrospective@lacolaco-plugins` を有効化
- `.gitignore_global` に `node_modules` を追加

## Test plan
- [x] `python3 -m json.tool claude/settings.json` で JSON 妥当性確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)