### PR TITLE
feat: enable kokoro-tts plugin

### DIFF
--- a/claude/settings.json
+++ b/claude/settings.json
@@ -70,7 +70,8 @@
     "session-handover@lacolaco-plugins": true,
     "protect-main-branch@lacolaco-plugins": true,
     "example-skills@anthropic-agent-skills": true,
-    "retrospective@lacolaco-plugins": true
+    "retrospective@lacolaco-plugins": true,
+    "kokoro-tts@lacolaco-plugins": true
   },
   "extraKnownMarketplaces": {
     "lacolaco-plugins": {


### PR DESCRIPTION
## Summary
- Enable `kokoro-tts@lacolaco-plugins` in `claude/settings.json`
- Reads Claude Code responses aloud locally via Kokoro TTS (Apple Silicon, Japanese voice `jf_alpha`)
- Toggle on/off with `/kokoro-tts:voice on|off|toggle|status`
- **Per-session scope**: each Claude Code session is independent; concurrent sessions do not speak over each other unless each opts in

## Dependencies
- Plugin definition lives in [lacolaco/claude-plugins#10](https://github.com/lacolaco/claude-plugins/pull/10) — merge that **first**
- This PR is based on `chore/settings-cleanup` (#44); merge that one first as well

## Test plan
- [ ] After both base PR (#44) and the plugin PR are merged, `/plugin marketplace add lacolaco/claude-plugins` and `/plugin install kokoro-tts@lacolaco-plugins` resolve
- [ ] `/kokoro-tts:voice on` in a session → that session reads responses aloud via afplay
- [ ] `/kokoro-tts:voice off` → playback stops on subsequent turns of that session
- [ ] A second concurrent Claude Code session with voice off stays silent regardless of the first session's state

🤖 Generated with [Claude Code](https://claude.com/claude-code)