### PR TITLE
chore: enable kokoro-tts and retrospective plugins, ignore node_modules

### DIFF
--- a/.gitignore_global
+++ b/.gitignore_global
@@ -1,4 +1,5 @@
 .DS_Store
+node_modules
 
 .claude/settings.local.json
 .claude/**/*.local.*

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -61,7 +61,9 @@
     "frontend-design@claude-plugins-official": true,
     "session-handover@lacolaco-plugins": true,
     "protect-main-branch@lacolaco-plugins": true,
-    "example-skills@anthropic-agent-skills": true
+    "example-skills@anthropic-agent-skills": true,
+    "kokoro-tts@lacolaco-plugins": true,
+    "retrospective@lacolaco-plugins": true
   },
   "extraKnownMarketplaces": {
     "lacolaco-plugins": {


### PR DESCRIPTION
## Summary
- \`claude/settings.json\`: enable \`kokoro-tts@lacolaco-plugins\` and \`retrospective@lacolaco-plugins\` in \`enabledPlugins\`
- \`.gitignore_global\`: add \`node_modules\`

Folds the previous two-PR split (#44 chore + #45 feat) into a single PR per request. The deny rules that the prior chore PR proposed removing are preserved here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)