### PR TITLE
chore(settings): sync settings.json to remove stale permissions and add voice config

### DIFF
--- a/claude/settings.json
+++ b/claude/settings.json
@@ -20,12 +20,8 @@
       "Bash(sh:*)",
       "Bash(for *)",
       "Bash(* &)",
-      "Bash(* echo \"---\" *)",
       "Bash(bash:*)",
-      "Bash(sed *)",
       "Bash(find * -exec *)",
-      "Bash(git -C:*)",
-      "Bash(gh api graphql:*)",
       "Bash(gh api -X PUT*)",
       "Bash(gh api -X POST*)",
       "Bash(gh api -X DELETE*)",
@@ -57,13 +53,25 @@
       "Bash(gh pr merge *)"
     ]
   },
+  "hooks": {
+    "PermissionRequest": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "terminal-notifier -message '承認待ちです' -title 'Claude Code' -activate \"${__CFBundleIdentifier:-com.apple.Terminal}\""
+          }
+        ]
+      }
+    ]
+  },
   "enabledPlugins": {
     "frontend-design@claude-plugins-official": true,
     "session-handover@lacolaco-plugins": true,
     "protect-main-branch@lacolaco-plugins": true,
     "example-skills@anthropic-agent-skills": true,
-    "kokoro-tts@lacolaco-plugins": true,
-    "retrospective@lacolaco-plugins": true
+    "retrospective@lacolaco-plugins": true,
+    "kokoro-tts@lacolaco-plugins": true
   },
   "extraKnownMarketplaces": {
     "lacolaco-plugins": {
@@ -79,21 +87,14 @@
       }
     }
   },
-  "hooks": {
-    "PermissionRequest": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "terminal-notifier -message '承認待ちです' -title 'Claude Code' -activate \"${__CFBundleIdentifier:-com.apple.Terminal}\""
-          }
-        ]
-      }
-    ]
-  },
   "language": "Japanese",
   "alwaysThinkingEnabled": true,
   "effortLevel": "high",
+  "voice": {
+    "enabled": true,
+    "mode": "hold"
+  },
   "autoMemoryEnabled": false,
-  "skipAutoPermissionPrompt": true
+  "skipAutoPermissionPrompt": true,
+  "voiceEnabled": true
 }


### PR DESCRIPTION
## Summary

main の HEAD に「消したはずの permission entries」が残っていた状態を解消する。working tree 側が「あるべき状態」だったため、その差分をそのままコミット。

## 変更内容

**消し忘れだった permission entries を削除：**
- \`Bash(* echo \"---\" *)\`
- \`Bash(sed *)\`
- \`Bash(git -C:*)\`
- \`Bash(gh api graphql:*)\`

**追加：**
- \`voice\` block (\`enabled: true\`, \`mode: \"hold\"\`)
- 末尾 \`voiceEnabled: true\`

**整理：**
- \`hooks\` block 位置移動
- \`enabledPlugins\` 順序変更（retrospective ↔ kokoro-tts）

## Test plan

- [ ] symlink 経由で \`~/.claude/settings.json\` が更新後に Claude Code が想定通り起動すること