### PR TITLE
revert(settings): restore settings.json to user-intended state

### DIFF
--- a/claude/settings.json
+++ b/claude/settings.json
@@ -20,8 +20,12 @@
       "Bash(sh:*)",
       "Bash(for *)",
       "Bash(* &)",
+      "Bash(* echo \"---\" *)",
       "Bash(bash:*)",
+      "Bash(sed *)",
       "Bash(find * -exec *)",
+      "Bash(git -C:*)",
+      "Bash(gh api graphql:*)",
       "Bash(gh api -X PUT*)",
       "Bash(gh api -X POST*)",
       "Bash(gh api -X DELETE*)",
@@ -53,25 +57,13 @@
       "Bash(gh pr merge *)"
     ]
   },
-  "hooks": {
-    "PermissionRequest": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "terminal-notifier -message '承認待ちです' -title 'Claude Code' -activate \"${__CFBundleIdentifier:-com.apple.Terminal}\""
-          }
-        ]
-      }
-    ]
-  },
   "enabledPlugins": {
     "frontend-design@claude-plugins-official": true,
     "session-handover@lacolaco-plugins": true,
     "protect-main-branch@lacolaco-plugins": true,
     "example-skills@anthropic-agent-skills": true,
-    "retrospective@lacolaco-plugins": true,
-    "kokoro-tts@lacolaco-plugins": true
+    "kokoro-tts@lacolaco-plugins": true,
+    "retrospective@lacolaco-plugins": true
   },
   "extraKnownMarketplaces": {
     "lacolaco-plugins": {
@@ -87,14 +79,21 @@
       }
     }
   },
+  "hooks": {
+    "PermissionRequest": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "terminal-notifier -message '承認待ちです' -title 'Claude Code' -activate \"${__CFBundleIdentifier:-com.apple.Terminal}\""
+          }
+        ]
+      }
+    ]
+  },
   "language": "Japanese",
   "alwaysThinkingEnabled": true,
-  "effortLevel": "high",
-  "voice": {
-    "enabled": true,
-    "mode": "hold"
-  },
+  "effortLevel": "xhigh",
   "autoMemoryEnabled": false,
-  "skipAutoPermissionPrompt": true,
-  "voiceEnabled": true
+  "skipAutoPermissionPrompt": true
 }


### PR DESCRIPTION
## Summary

PR #48 (52f5753) は誤マージ。Claude Code 本体が裏で書き換えた settings.json (4 deny entries 削除 + voice 追加 等) をユーザー意図と取り違えて main に反映してしまった。本 PR でユーザー手動編集の正しい状態に戻す。

## 復元内容

- deny に復活: \`Bash(* echo \"---\" *)\`, \`Bash(sed *)\`, \`Bash(git -C:*)\`, \`Bash(gh api graphql:*)\`
- 削除: \`voice\` block, \`voiceEnabled: true\`
- 順序復元: \`enabledPlugins\` (kokoro-tts → retrospective)
- 位置復元: \`hooks\` block
- ユーザー手動: \`effortLevel: xhigh\`

## Test plan

- [ ] symlink 経由で \`~/.claude/settings.json\` がユーザー意図通りに戻ること
- [ ] 次回 Claude Code 起動時に再書き換えが起きないかを観察