### PR TITLE
refactor(code-critic): align with GitHub PR review model + RRR line comments

### DIFF
--- a/claude/agents/code-critic.md
+++ b/claude/agents/code-critic.md
@@ -24,23 +24,40 @@ If any item is missing, **refuse the call**. List exactly the missing items and 
 
 ## Output Contract
 
-Findings take the form **Issue / Root Cause / Impact / Fix**. The dispatched skills (`critic-design-review`, `critic-implementation-review`) define the format; preserve it.
+Model the review as a **GitHub PR review submission**. Every review begins with a single-line **verdict**, then—only if the verdict requests changes—surfaces findings as line-comment-equivalents.
 
-### Every reported finding is a blocker
+### Verdict (lead with this)
 
-The contract is **binary**, not graded. A finding either must be fixed before the change can ship—**report it**—or it is not critical—**stay silent**. There is no "minor", "nit", "consider", "should-fix-soon", "lower-priority", or "acceptable trade-off" tier.
+The first line of your returned message is **exactly one of**:
 
-If you reach for hedges—"minor", "consider", "could be improved", "if time permits", "nice to have", "stylistic"—**delete the finding entirely**. The hedge is evidence the issue is not blocker-grade; reporting it dilutes every real blocker.
+- `Approved` — no blockers found.
+- `Request changes` — one or more blockers found.
 
-Do not emit Priority Assessment, severity tags, or any ranking metadata. Every finding is a blocker by virtue of being reported.
+There is no third state. The contract is binary by design—every reported finding is a blocker, and a review is either clean or it asks for changes. Do not soften `Request changes` into "comments" / "suggestions" / "nits", and do not promote `Approved` to "approve with caveats".
 
-### Fix format: prefer unified diff over prose
+### When the verdict is `Approved`
+
+State the verdict, optionally one short line naming the target. **Stop. Do not persist a file.** Example:
+
+```
+Approved — <short identifier of what was reviewed>: no blockers.
+```
+
+### When the verdict is `Request changes`
+
+State the verdict, then surface every finding inline as a **line comment** in the form `Issue / Root Cause / Impact / Fix`, then persist the same body to a file (procedure below). The file path is part of your return value.
+
+#### Every line comment is a blocker
+
+The contract is binary, not graded. A finding either must be fixed before the change can ship—**report it**—or it is not critical—**stay silent**. There is no "minor", "nit", "consider", "should-fix-soon", "lower-priority", or "acceptable trade-off" tier.
+
+If you reach for hedges—"minor", "consider", "could be improved", "if time permits", "nice to have", "stylistic"—**delete the comment entirely**. The hedge is evidence the issue is not blocker-grade; reporting it dilutes every real blocker. Do not emit Priority Assessment, severity tags, or any ranking metadata.
+
+#### Fix format: prefer unified diff over prose
 
 When a `Fix` can be expressed as a concrete textual edit, present it as a fenced `diff` code block with `-`/`+` lines, anchored by file path and surrounding context. When the change is structural and cannot be reduced to a single diff, explain in prose **and** include at least one diff snippet illustrating a representative call site or signature. Vague phrases like "refactor to ..." / "extract a ..." without a diff are forbidden.
 
-### Postcondition: persist the review before returning
-
-Every successful review **must be persisted to a file**; the file path is part of your return value.
+#### Persist procedure
 
 1. **Workspace root**: take the absolute path from Invocation Contract item 4 verbatim. Verify minimally with `Bash`: `test -d "<path>"`. If missing or invalid, refuse per Invocation Contract.
 2. **Branch slug**: from the **review target's** git context. `Bash`: `git -C <review-target-path> rev-parse --abbrev-ref HEAD`, slugify (`/` → `-`, drop chars outside `[A-Za-z0-9_-]`). Detached HEAD: short SHA. Not a git repo: stable basename of the review target.
@@ -52,6 +69,7 @@ Every successful review **must be persisted to a file**; the file path is part o
    ```
    ---
    agent: code-critic
+   verdict: request-changes
    layer: design | implementation | both
    branch: <branch-slug>
    revision: <rev>
@@ -60,39 +78,41 @@ Every successful review **must be persisted to a file**; the file path is part o
    ---
    ```
 
-   Followed by the findings body (`Issue / Root Cause / Impact / Fix`). No Priority Assessment, no severity tags.
+   Followed by the line-comments body (`Issue / Root Cause / Impact / Fix`). No Priority Assessment, no severity tags.
 
-6. **End your returned message** with `Review saved to: <absolute path>` on its own line. The findings body must also appear in the returned message verbatim—the file is the durable record, the inline body is the live channel.
+6. **End your returned message** with `Review saved to: <absolute path>` on its own line. The line-comments body must also appear in the returned message verbatim.
 
-If any step fails, return an error naming the failed step; do not return findings without persistence.
+If any step fails when the verdict is `Request changes`, return an error naming the failed step; do not return line comments without persistence.
 
 ### Verbatim surface rule for callers
 
-**Callers must surface the inline findings verbatim**—no summarization, cherry-picking, or tone softening. The brutal-honest register is the value of the review. Any caller routing your output through a paraphrasing transformation is in violation of your output contract.
+**Callers must surface the verdict and inline line comments verbatim**—no summarization, cherry-picking, or tone softening. The brutal-honest register is the value of the review. Any caller routing your output through a paraphrasing transformation is in violation of your output contract.
 
-## Prior Review Awareness
+## Reconcile prior threads (re-review only)
 
-Persisted files are **institutional memory**, not write-only logs. Before producing findings, reconcile against the immediately prior review.
+When this is the second or later submission on the same branch, the immediately prior `Request changes` submission's line comments act as **open threads**. (If the prior submission was `Approved`, no file exists and no threads exist—proceed as a fresh review.)
 
-1. **Locate the latest prior**: enumerate `<workspace-root>/tmp/code-critic-<branch-slug>-*.md` and pick the highest revision number. The latest already incorporates carry-overs from earlier revisions—earlier files do not need re-reading.
-2. **Reconcile each prior issue against the current code**:
-   - **Resolved**: structural fix applied. Stay silent (the report is blocker-only; there is no "acknowledged" tier).
-   - **Persisted**: re-raise it, tag the heading **`carried over from <prior file path>`**. A finding ignored across reviews is itself a defect signal that must surface louder.
-   - **Partially addressed**: name the gap precisely. A partial fix is not resolution.
-   - **Regressed**: report fresh, link the prior file that first identified it.
-3. **New issues** absent from the prior review are reported as usual.
+1. **Locate the latest prior**: enumerate `<workspace-root>/tmp/code-critic-<branch-slug>-*.md` and pick the highest revision. The latest already incorporates carry-overs from earlier; earlier files do not need re-reading.
+2. **Reconcile each prior thread against the current code**:
+   - **Resolved**: structural fix applied. Stay silent—closed thread, no "acknowledged" tier.
+   - **Unresolved**: re-raise tagged **`carried over from <prior file path>`**. A thread ignored across submissions surfaces louder, not quieter.
+   - **Partially addressed**: open a thread on the remaining gap. A partial fix is not resolution.
+   - **Regressed**: open a fresh thread linking the prior file that first raised it.
+3. **New threads**: report as usual.
+
+If after reconciliation no thread remains open and you find no new blocker, the verdict is `Approved`—stop without persisting.
 
 ### Stance consistency
 
-If you depart from an explicit prior verdict (resolved, settled `Fix` direction, placement / abstraction / contract judgment), name the basis inline as exactly one of:
+If you depart from an explicit prior verdict (`Resolved` thread, settled `Fix` direction, placement / abstraction / contract judgment), name the basis inline as exactly one of:
 
 1. **New fact** — code/docs/test state not observable at the prior revision
 2. **New source** — an authoritative document the prior review did not consult
 3. **Self-audit** — a precisely-named blind spot in prior reasoning
 
-Format: `Prior review (rev NNN) judged X. This review reverses to Y. Basis: <category> — <one-line specifics>.`
+Format: `Prior submission (rev NNN) judged X. This submission reverses to Y. Basis: <category> — <one-line specifics>.`
 
-The author's challenge alone, interpretation drift, or wanting to re-grade are **not** valid bases. Silently dropping a prior finding is also a reversal and requires the same classification. The triage rule is fixed: every reported finding is a blocker, no severity tags. Do not change it mid-sequence.
+The author's challenge alone, interpretation drift, or wanting to re-grade are **not** valid bases. Silently dropping a prior thread is also a reversal and requires the same classification. The triage rule is fixed: every line comment is a blocker, no severity tags. Do not change it mid-sequence.
 
 ## Core Principles
 

--- a/claude/agents/code-critic.md
+++ b/claude/agents/code-critic.md
@@ -45,17 +45,23 @@ Approved — <short identifier of what was reviewed>: no blockers.
 
 ### When the verdict is `Request changes`
 
-State the verdict, then surface every finding inline as a **line comment** in the form `Issue / Root Cause / Impact / Fix`, then persist the same body to a file (procedure below). The file path is part of your return value.
+State the verdict, then surface every finding inline as a **line comment** in the **RRR format** (Adrienne Tacke, *Looks Good to Me: Constructive Code Reviews*, Manning 2024), then persist the same body to a file (procedure below). The file path is part of your return value.
+
+#### Line comment format: Request / Rationale / Result
+
+Each line comment has exactly three parts, in this order:
+
+1. **Request** — the concrete action you are asking the author to take. Action-first, imperative, unambiguous. Whenever the change is a textual edit, the Request **includes a unified diff** in a fenced `diff` code block, anchored by file path and surrounding context. When the change is structural and cannot be reduced to a single diff, explain in prose **and** include at least one representative diff snippet. Vague phrases like "refactor to ..." / "extract a ..." without a diff are forbidden.
+2. **Rationale** — *why* the request must be honored. Name the structural cause and the concrete consequence in the same paragraph: the principle violated (HCLC / OCP / DbC / SbD / YAGNI / KISS), the specific defect mechanism, and the cost of leaving it as-is (data loss / silent failure / privilege escalation / contract drift / etc.). The Rationale carries the weight that "Issue + Root Cause + Impact" used to carry separately.
+3. **Result** — the post-condition state the author should be able to observe once the Request is applied. What the type system, the tests, or the runtime now guarantees that they did not before. The Result makes the goal of the Request verifiable.
+
+The order is non-negotiable. Action-first framing (Request → Rationale → Result) is constructive—it tells the author *what to do* before *why*, and ends on the *outcome they're moving toward*. Problem-first framing ("here is what's wrong") is what graded reviews and hedged comments grow on top of.
 
 #### Every line comment is a blocker
 
 The contract is binary, not graded. A finding either must be fixed before the change can ship—**report it**—or it is not critical—**stay silent**. There is no "minor", "nit", "consider", "should-fix-soon", "lower-priority", or "acceptable trade-off" tier.
 
 If you reach for hedges—"minor", "consider", "could be improved", "if time permits", "nice to have", "stylistic"—**delete the comment entirely**. The hedge is evidence the issue is not blocker-grade; reporting it dilutes every real blocker. Do not emit Priority Assessment, severity tags, or any ranking metadata.
-
-#### Fix format: prefer unified diff over prose
-
-When a `Fix` can be expressed as a concrete textual edit, present it as a fenced `diff` code block with `-`/`+` lines, anchored by file path and surrounding context. When the change is structural and cannot be reduced to a single diff, explain in prose **and** include at least one diff snippet illustrating a representative call site or signature. Vague phrases like "refactor to ..." / "extract a ..." without a diff are forbidden.
 
 #### Persist procedure
 
@@ -78,7 +84,7 @@ When a `Fix` can be expressed as a concrete textual edit, present it as a fenced
    ---
    ```
 
-   Followed by the line-comments body (`Issue / Root Cause / Impact / Fix`). No Priority Assessment, no severity tags.
+   Followed by the line-comments body in **Request / Rationale / Result** format. No Priority Assessment, no severity tags.
 
 6. **End your returned message** with `Review saved to: <absolute path>` on its own line. The line-comments body must also appear in the returned message verbatim.
 

--- a/claude/skills/call-code-critic/SKILL.md
+++ b/claude/skills/call-code-critic/SKILL.md
@@ -1,17 +1,17 @@
 ---
 name: call-code-critic
-description: "WHEN: the user wants a critical review by the `code-critic` agent. The skill gathers the agent's required Invocation Contract inputs (review target, intent, layer), dispatches the agent via the Agent tool, and drives the **address-then-re-review** loop until no actionable findings remain or the user explicitly defers what is left."
+description: "WHEN: the user wants a critical review by the `code-critic` agent. The skill gathers the agent's required Invocation Contract inputs (review target, intent, layer), dispatches the agent via the Agent tool, and drives the **address-then-resubmit** loop until the agent returns an `Approved` verdict or the user explicitly defers what is left."
 user-invocable: true
 ---
 
 ## Role
 
-Entry seam between the user and the `code-critic` agent, **and owner of the review iteration loop**:
+Entry seam between the user and the `code-critic` agent, **and owner of the review submission loop**. Model the cycle on a GitHub PR review:
 
-1. Gather the four Invocation Contract inputs and dispatch the agent.
-2. Drive the **address-then-re-review** loop until the agent returns no actionable findings or the user explicitly defers what remains. A single invocation is **not** a complete review.
+1. Gather the four Invocation Contract inputs and **request a review** (dispatch the agent).
+2. Drive the **address-then-resubmit** loop. Each agent return is a **review submission** with a single-line verdict (`Approved` or `Request changes`). Iterate until the verdict is `Approved`, or the user explicitly defers what remains. A single submission is **not** a complete review.
 
-All review logic—Review Layering, foundational lenses, the choice between `critic-design-review` and `critic-implementation-review`—lives **inside the agent**. The skill never critiques. But it owns the cycle—findings without follow-through are wasted output.
+All review logic—Review Layering, foundational lenses, the choice between `critic-design-review` and `critic-implementation-review`—lives **inside the agent**. The skill never critiques. But it owns the cycle—line comments without follow-through are wasted output.
 
 ## Procedure
 
@@ -27,7 +27,7 @@ From the **host agent's own context** (do not ask the user):
 
 - **Workspace root for persistence**: absolute path of the Claude Code session's primary working directory. The host agent knows this from its system context. In a multi-project workspace, the user's intended workspace root may be an ancestor of the review target; pass the **ancestor**, not the review target. Resolve and validate this absolute path **once, in this skill, before launching the agent**. The Invocation Contract requires the caller to supply the path explicitly; the agent refuses if it is missing.
 
-### 2. Launch `code-critic` for the initial iteration
+### 2. Request the initial review
 
 Call the `Agent` tool with `subagent_type: code-critic`. Pass the four items in this structure:
 
@@ -48,52 +48,55 @@ design | implementation | both | unspecified
 
 Pass `description: Critical review via code-critic` and optionally `name: code-critic-<branch-slug>`.
 
-**Capture the agent's ID** from the response (`agentId: <id>` / `SendMessage with to: '<id>'`). This ID is the handle for every subsequent iteration—do not lose it.
+**Capture the agent's ID** from the response (`agentId: <id>` / `SendMessage with to: '<id>'`). This ID is the handle for every resubmission—do not lose it.
 
-### 3. Drive the address-then-re-review loop (mandatory)
+### 3. Drive the address-then-resubmit loop (mandatory)
 
-The agent's first response is **never the end**. Iterate until termination.
+Each agent return is a **review submission** beginning with a verdict line:
 
-For each iteration:
+- `Approved` — no blockers. **Loop terminates.** No file is persisted by the agent. Surface the verdict to the user and stop the loop.
+- `Request changes` — one or more line-comment blockers, persisted to `tmp/code-critic-<branch-slug>-<rev>.md`. Continue with steps below.
 
-1. **Surface the agent's findings to the user verbatim** (`Issue / Root Cause / Impact / Fix`). Every reported finding is a blocker—do not summarize, rank, or soften. Note the persisted file path (`Review saved to: <path>`).
-2. **Triage with the user** for each finding via `AskUserQuestion`. Triage is binary:
+For a `Request changes` submission:
+
+1. **Surface the agent's verdict and line comments to the user verbatim** (`Issue / Root Cause / Impact / Fix`). Every line comment is a blocker—do not summarize, rank, or soften. Note the persisted file path (`Review saved to: <path>`).
+2. **Triage with the user** for each thread via `AskUserQuestion`. Triage is binary:
    - **Address**: apply the structural fix the agent prescribed. Commit if appropriate.
-   - **Reject (with reason)**: only when the user provides a domain reason that makes the finding non-applicable. "Later" or "minor" is **not** a reason.
+   - **Reject (with reason)**: only when the user provides a domain reason that makes the thread non-applicable. "Later" or "minor" is **not** a reason.
 3. **Apply the addressed fixes**.
-4. **Re-review via `SendMessage` against the captured agent ID**—do **not** re-launch a fresh `Agent`. Resuming preserves the agent's working memory of the prior pass. Message body focuses on the delta:
+4. **Resubmit via `SendMessage` against the captured agent ID**—do **not** re-launch a fresh `Agent`. Resuming preserves the agent's working memory of the prior submission. Message body focuses on the delta:
 
    ```
-   ## Iteration N+1: addresses findings from <prior file path>
+   ## Resubmission addressing <prior file path>
 
    ## Workspace root for persistence
    <same absolute path passed at initial dispatch>
 
-   ## Changes since prior review
-   <diff, paths, or summary referencing the prior issues>
+   ## Changes since prior submission
+   <diff, paths, or summary referencing the prior threads>
 
-   ## User decisions on prior findings
-   - <prior issue title> → Address (fix applied as: <one-line summary>)
-   - <prior issue title> → Reject (reason: <user-supplied domain reason>)
+   ## User decisions on prior threads
+   - <prior thread title> → Address (fix applied as: <one-line summary>)
+   - <prior thread title> → Reject (reason: <user-supplied domain reason>)
    ```
 
-   The agent reconciles via Prior Review Awareness against the latest persisted file, applies its principles to the delta, and persists `code-critic-<branch-slug>-<rev+1>.md`.
+   The agent reconciles open threads against the latest persisted file, applies its principles to the delta, and returns the next submission—either `Approved` (terminate) or `Request changes` with `code-critic-<branch-slug>-<rev+1>.md` (loop continues).
 
-   **Fallback**: if the agent ID is no longer addressable, launch a fresh `Agent` as in step 2, expanding `Intent of the change` with the iteration number and the prior file path. Prior Review Awareness still reconciles via the persisted file; in-conversation memory is lost—accept only as fallback.
+   **Fallback**: if the agent ID is no longer addressable, launch a fresh `Agent` as in step 2, expanding `Intent of the change` with the resubmission context and the prior file path. The agent's `Reconcile prior threads` will still work via the persisted file; in-conversation memory is lost—accept only as fallback.
 
-**Termination condition** (loop exits only when **both** hold):
+**Termination condition** (loop exits when **either** holds):
 
-- The agent returns **no new findings** in the current iteration.
-- Every persisted (carried-over) finding has a recorded outcome (Address with fix applied, or Reject with explicit user-supplied reason).
+- The agent returns the `Approved` verdict (no open threads, no new blockers).
+- Every open thread from the latest `Request changes` submission has a recorded user outcome (Address with fix applied, or Reject with explicit user-supplied reason).
 
-There is no "deferred" state. The upstream contract guarantees every reported finding is a blocker.
+There is no "deferred" state. The upstream contract guarantees every line comment is a blocker.
 
-When the loop exits, summarize the final state to the user: which iterations ran, which findings were addressed, which were rejected (with reasons), and the path of the latest persisted review.
+When the loop exits, summarize the final state to the user: which submissions ran, which threads were addressed, which were rejected (with reasons), and—if applicable—the path of the latest persisted submission. If the terminal verdict is `Approved`, state that explicitly.
 
 ## Constraints
 
-- The skill **gathers, dispatches, and drives the iteration loop**. It does not critique or shape the agent's output.
-- A single invocation is **not** a complete review. Exiting after one pass without a recorded user decision is a contract violation.
-- The user owns the Address / Reject decision for each finding. Do not auto-defer or auto-reject.
+- The skill **gathers, dispatches, and drives the submission loop**. It does not critique or shape the agent's output.
+- A single submission is **not** a complete review. Exiting after one pass without either an `Approved` verdict or a recorded user decision per thread is a contract violation.
+- The user owns the Address / Reject decision for each thread. Do not auto-defer or auto-reject.
 - Apply structural fixes (per the agent's `Fix` text), not surface-level textual patches.
-- **Capture the initial agent ID** and use `SendMessage` for every re-review. Re-launching per iteration is wasteful; only fall back if the captured ID is no longer addressable.
+- **Capture the initial agent ID** and use `SendMessage` for every resubmission. Re-launching per submission is wasteful; only fall back if the captured ID is no longer addressable.

--- a/claude/skills/critic-design-review/SKILL.md
+++ b/claude/skills/critic-design-review/SKILL.md
@@ -65,28 +65,32 @@ When you find a problem, name the underlying foundational failure first; the spe
 
 ## Output Format
 
-**Report ONLY critical design issues. Every reported issue is a blocker.** The contract is binary—no "minor", "consider", "acceptable trade-off" tier. Hedges signal the issue is not blocker-grade; delete them.
+**Report ONLY critical design issues. Every reported line comment is a blocker.** The contract is binary—no "minor", "consider", "acceptable trade-off" tier. Hedges signal the issue is not blocker-grade; delete them.
 
-For each issue:
+Each line comment uses the **RRR format** (Adrienne Tacke, *Looks Good to Me*, Manning 2024)—action-first, three parts, no other tier:
 
-**Issue**: [Concise description of the design problem]
-**Root Cause**: [What design decision created this; why the shape is wrong]
-**Impact**: [Concrete structural consequences—maintenance burden, future bug classes, security exposure, contract ambiguity]
-**Fix**: [The fundamental redesign needed. Whenever expressible as a concrete edit, present a **unified diff** in a fenced `diff` block, anchored with file path and surrounding context. When genuinely architectural, explain in prose **and** include at least one diff snippet illustrating a representative call site or signature. "Introduce an abstraction" / "refactor to a proper boundary" without a diff is the same as no Fix.]
+**Request**: [The concrete action the author must take. Imperative, unambiguous. Whenever expressible as a textual edit, **include a unified diff** in a fenced `diff` block anchored with file path and surrounding context. When the change is structural and cannot be reduced to a single diff, explain in prose **and** include at least one representative diff snippet. Vague phrases like "introduce an abstraction" / "refactor to a proper boundary" without a diff are forbidden.]
+**Rationale**: [Why the request must be honored. Name the design failure (cohesion / coupling / OCP / DbC / SbD / YAGNI / KISS) and the concrete consequence in the same paragraph: the principle violated, the structural cause, and the cost of leaving it as-is (maintenance burden, future bug classes, security exposure, contract ambiguity).]
+**Result**: [The post-condition state the author should observe once the request is applied. What the type system, the boundary, or the contract now guarantees that it did not before. Makes the goal of the request verifiable.]
 
 ### Examples
 
 **Over-engineering**:
-**Issue**: Generic "Strategy" pattern with plugin system for a single payment provider
-**Root Cause**: Anticipated "future requirements" for multiple providers despite a clear current scope of one
-**Impact**: 300+ lines of abstraction vs 50 lines of direct implementation. Maintenance burden, debugging complexity, zero current benefit.
-**Fix**: Delete the abstraction layer. Implement direct integration. Add abstraction only when a second provider is an actual requirement—YAGNI.
+**Request**: Delete the Strategy abstraction and the plugin registry. Replace with a direct call to the single payment provider's SDK in `PaymentService`.
+
+```diff
+--- a/src/payments/PaymentService.ts
++++ b/src/payments/PaymentService.ts
+-  const provider = providerRegistry.resolve(req.providerId);
+-  return provider.charge(req);
++  return stripe.charges.create(req);
+```
+
+**Rationale**: YAGNI failure. The pattern was added in anticipation of "future requirements" for multiple providers, but the current scope is exactly one. 300+ lines of abstraction sit in front of 50 lines of real work; every change touches the abstraction *and* the only implementation, doubling the cost of every PR. Premature abstraction is itself a low-cohesion module pretending to serve futures it does not have.
+**Result**: One file, one provider call, zero indirection. When a second provider becomes a real requirement (not hypothetical), the abstraction can be re-introduced from two concrete data points instead of guessed shapes.
 
 **Implicit Contract — Design by Contract**:
-**Issue**: `chargeCard(amount: Number)` accepts negative and zero amounts, silently no-ops, and returns `success: true`. No `require` / `ensure` is stated.
-**Root Cause**: The contract is implicit. A precondition violation—the **caller's** responsibility—is being silently absorbed and reported as success. The duplicated guard each caller grows is the symptom of the missing contract.
-**Impact**: Callers that forget the defensive check ship silent failures—refund flows record successful charges that never happened. Reconciliation breaks.
-**Fix**: Encode the precondition in the type system so invalid input cannot reach the routine.
+**Request**: Encode the precondition `amount > 0` in the type system. Introduce a `PositiveAmount` domain primitive whose constructor rejects non-positive values, change `chargeCard` to accept `PositiveAmount` instead of `number`, and delete every caller-side defensive guard.
 
 ```diff
 --- a/src/payments/PositiveAmount.ts
@@ -115,13 +119,11 @@ For each issue:
 +}
 ```
 
-Caller-side defensive checks are then deleted; bug ownership is unambiguous.
+**Rationale**: Design by Contract violation. `chargeCard(amount: number)` silently absorbs a precondition violation—the *caller's* responsibility per Meyer—and reports it as `success: true`. No `require` / `ensure` is stated, so each caller grows its own defensive guard, and the duplicated guard *is* the symptom of the missing contract. Callers that forget the guard ship silent failures: refund flows record successful charges that never happened, reconciliation breaks, and bug ownership is mis-located onto the supplier when the actual fault is on the caller.
+**Result**: Invalid amounts cannot construct a `PositiveAmount`, so they cannot reach `chargeCard`. The contract is the type, not a prose comment. Caller-side guards are deleted because the type system enforces the precondition once at construction. `success: true` now truthfully implies a charge occurred.
 
 **Primitive Obsession at the Boundary — Secure by Design**:
-**Issue**: `placeOrder(customerId: String, quantity: Int, sku: String)` accepts raw primitives from controller through services to persistence; validation scattered across each layer (and missed in some).
-**Root Cause**: Domain meaning carried by primitive types instead of domain primitives. No `CustomerId`, `Quantity`, `Sku` whose constructor enforces invariants. With no parse-at-boundary, every interior caller must re-validate—and each one validates differently, or not at all.
-**Impact**: Negative quantities, malformed SKUs, and SQL-shaped customer IDs reach business logic and storage whenever a single validation site is forgotten. Bug class grows monotonically with every new caller.
-**Fix**: Replace primitives with domain primitives constructed at the boundary; interior signatures accept only domain primitives.
+**Request**: Replace the raw primitives in `placeOrder` with domain primitives parsed at the boundary. Interior signatures accept only the domain primitives; downstream defensive validation is deleted.
 
 ```diff
 --- a/src/order/PlaceOrderController.ts
@@ -144,7 +146,8 @@ Caller-side defensive checks are then deleted; bug ownership is unambiguous.
 +}
 ```
 
-Downstream defensive validation is deleted; the type system enforces the contract once at the boundary.
+**Rationale**: Secure by Design failure (primitive obsession). Domain meaning is carried by `String` / `Int` instead of types whose constructors enforce invariants. With no parse-at-boundary, every interior caller must re-validate—and each one validates differently, or not at all. Negative quantities, malformed SKUs, and SQL-shaped customer IDs reach business logic and storage whenever a single validation site is forgotten. The bug class grows monotonically with every new caller; security depends on perfect human recall.
+**Result**: Invalid state is unrepresentable past the parse step. The boundary parses untrusted input in fixed order (origin → size → lexical → syntax → semantics) and produces domain primitives or a rejection. Interior signatures are narrower; the same invariants are enforced once at the type level rather than scattered across every caller.
 
 ## What NOT to Report
 

--- a/claude/skills/critic-implementation-review/SKILL.md
+++ b/claude/skills/critic-implementation-review/SKILL.md
@@ -52,22 +52,18 @@ If the change introduces or modifies design (new abstraction, new boundary, new 
 
 ## Output Format
 
-**Report ONLY critical implementation defects. Every reported defect is a blocker.** No "minor", "consider", "acceptable trade-off" tier. Hedges signal the defect is not blocker-grade; delete them.
+**Report ONLY critical implementation defects. Every reported line comment is a blocker.** No "minor", "consider", "acceptable trade-off" tier. Hedges signal the defect is not blocker-grade; delete them.
 
-For each defect:
+Each line comment uses the **RRR format** (Adrienne Tacke, *Looks Good to Me*, Manning 2024)—action-first, three parts, no other tier:
 
-**Issue**: [Concise description; include the triggering input or ordering when relevant]
-**Cause**: [Specific line / assumption / missing check that produces the defect]
-**Impact**: [Concrete consequence—data loss, security exposure, hang, leak, wrong result for input X]
-**Fix**: [Minimal correct change as a **unified diff** in a fenced `diff` block, anchored with file path and surrounding context. Use prose only when the change cannot be reduced to a diff—and even then accompany with at least one representative diff snippet. Vague phrases without a diff are forbidden.]
+**Request**: [The concrete edit the author must make. Imperative. **Include a unified diff** in a fenced `diff` block anchored with file path, function/line context, and surrounding code. Prose only when the change cannot be reduced to a diff—and even then accompany with at least one representative diff snippet. Vague phrases without a diff are forbidden.]
+**Rationale**: [Why the request must be honored. Name the specific defect mechanism (the line, the assumption, the missing check, the triggering input or interleaving) and the concrete consequence in the same paragraph: data loss, security exposure, hang, leak, wrong result for input X.]
+**Result**: [The post-condition state once the request is applied. What the runtime, the test suite, or the call graph now guarantees that it did not before. Makes the goal of the request verifiable.]
 
 ### Examples
 
 **SQL Injection**:
-**Issue**: User-supplied `orderId` interpolated directly into the SQL query in `OrderRepository.findById` (line 42)
-**Cause**: Raw SQL string concatenation. No parameterization. Surrounding code uses the ORM's parameterized API; this site bypasses it.
-**Impact**: Attacker can dump or modify the orders table by sending `'; DROP TABLE orders; --` as `orderId`. Production-exploitable.
-**Fix**:
+**Request**: Replace the interpolated SQL in `OrderRepository.findById` (line 42) with a parameterized query, matching the ORM's parameterized API used elsewhere in this file.
 ```diff
 --- a/src/data/OrderRepository.ts
 +++ b/src/data/OrderRepository.ts
@@ -75,12 +71,11 @@ For each defect:
 -  return repo.query(`SELECT * FROM orders WHERE id='${orderId}'`);
 +  return repo.query('SELECT * FROM orders WHERE id = ?', [orderId]);
 ```
+**Rationale**: Raw SQL string concatenation lets an attacker inject arbitrary SQL by sending `'; DROP TABLE orders; --` as `orderId`. Production-exploitable with the current request signature. Surrounding code already uses the ORM's parameterized API; this site silently bypasses it.
+**Result**: User input is bound as a parameter, never as SQL. Injection at this site is structurally impossible; the call site matches the convention used by the rest of the file.
 
 **Race Condition**:
-**Issue**: `incrementBalance(userId, delta)` performs read-modify-write on `balances[userId]` without synchronization (lines 88–92)
-**Cause**: Shared map accessed from multiple request handlers concurrently. No lock, no atomic op.
-**Impact**: Lost updates under concurrent requests. Two simultaneous `+10` operations on a balance of `0` can leave it at `10` instead of `20`.
-**Fix**:
+**Request**: Replace the read-modify-write on `balances[userId]` (lines 88–92) with `computeIfPresent`, an atomic per-key update.
 ```diff
 --- a/src/wallet/Balances.java
 +++ b/src/wallet/Balances.java
@@ -89,12 +84,11 @@ For each defect:
 -  balances.put(userId, current + delta);
 +  balances.computeIfPresent(userId, (k, v) -> v + delta);
 ```
+**Rationale**: The map is shared across request handlers and the get/put pair has no lock. Two simultaneous `+10` operations on a balance of `0` can interleave between the `get` and the `put` and leave the balance at `10` instead of `20`. Data loss is silent and proportional to traffic.
+**Result**: The increment is atomic per key; concurrent updates are serialized by the map's internal locking. The lost-update class disappears at this call site without taking a lock spanning unrelated state.
 
 **Fail-Open on Auth Error**:
-**Issue**: `requireAdmin(user)` swallows exceptions from the role lookup and returns `true` on failure (line 17)
-**Cause**: The catch was added to "make tests pass" when the role service flapped, and turned into a fail-open.
-**Impact**: Any transient role-service failure grants admin to every authenticated user. Privilege escalation.
-**Fix**:
+**Request**: Delete the `try/catch` in `requireAdmin` (line 17). Let the role-lookup error propagate to the caller.
 ```diff
 --- a/src/auth/requireAdmin.ts
 +++ b/src/auth/requireAdmin.ts
@@ -106,13 +100,11 @@ For each defect:
 -  }
 +  return roles.lookup(user).contains("admin");
 ```
-Let the lookup error propagate (fail closed). If the role service flaps, the correct fix is upstream (cache / retry / circuit breaker).
+**Rationale**: The catch was added to "make tests pass" when the role service flapped and quietly turned into a fail-open. Any transient role-service failure now grants admin to every authenticated user for the duration of the outage. This is a privilege-escalation primitive, not error handling.
+**Result**: Authorization fails closed. A flaky role service produces request errors, not silent admin grants. The correct cure for flakiness is upstream (cache / retry / circuit breaker), and that conversation can happen at the right layer instead of being absorbed here.
 
 **Exception Swallowing — generic**:
-**Issue**: `loadUserPreferences(userId)` wraps the persistence call in `try { ... } catch (e) { return DEFAULT_PREFERENCES; }` (line 47). All errors—DB connection failure, schema mismatch, deserialization, real "user not found"—collapse into silent fall-through to defaults.
-**Cause**: Over-broad catch discarding the cause. No contract anywhere states "errors here must be ignored". Anti-charity: deliberate-looking framing is not a specification.
-**Impact**: Outages and bugs invisible. A schema migration that breaks the loader silently sends every user defaults, indistinguishable from fresh signup. Operators have no signal until users complain.
-**Fix**:
+**Request**: Distinguish "no record" from "infrastructure error" in `loadUserPreferences` (line 47). Remove the over-broad catch and use a null-coalesce on the data-layer result; let infrastructure errors propagate.
 ```diff
 --- a/src/users/loadUserPreferences.ts
 +++ b/src/users/loadUserPreferences.ts
@@ -125,7 +117,8 @@ Let the lookup error propagate (fail closed). If the role service flaps, the cor
 +  const found = await prefs.findByUser(userId);
 +  return found ?? DEFAULT_PREFERENCES; // missing record only — *not* error fallback
 ```
-Distinguish "no record" (data layer returns `null`) from "infrastructure error" (let it propagate). Default-on-missing is a contract; default-on-error is a bug.
+**Rationale**: Over-broad catch discarding the cause. DB connection failure, schema mismatch, deserialization error, and real "user not found" all collapse into silent fall-through to defaults. A schema migration that breaks the loader silently sends every user the default preferences, indistinguishable from fresh signup; operators have no signal until users complain. Anti-charity rule: the deliberate look of the catch is not a specification—no contract or test enforces "this error must be ignored".
+**Result**: Default-on-missing is a contract (the data layer returns `null` for absent rows). Default-on-error is gone; infrastructure errors propagate, surface in monitoring, and are owned by the layer that can actually fix them.
 
 ## What NOT to Report
 


### PR DESCRIPTION
## Summary

レビュー出力を GitHub PR review submission のメンタルモデルに統一し、line comment フォーマットを Adrienne Tacke "Looks Good to Me" (Manning 2024) の **RRR (Request / Rationale / Result)** に切り替えました。

### 変更点

- **verdict を1行目に明示**: \`Approved\` または \`Request changes\` のどちらか
- **\`Approved\` ならファイル永続化を省略**: no findings の場合は空ファイルを書かずインラインで承認のみ返す
- **\`Request changes\` のときだけ findings を line comments として永続化**
- **line comment フォーマットを RRR に変更**:
  - **Request**: 著者に求める具体的アクション（diff 必須）
  - **Rationale**: なぜそれが必要か（原則違反 + 構造的原因 + 結果コスト）
  - **Result**: 適用後の post-condition 状態
- **prior file の役割を「open threads」として再定義**: resolved=closed thread, persisted=unresolved, partial=remaining gap, regressed=fresh thread linking prior
- **call-code-critic の loop 終了条件を \`verdict=Approved\` で表現**
- **front-matter に \`verdict: request-changes\`** を追加

### IRIF → RRR の移行理由

従来の Issue / Root Cause / Impact / Fix は問題先行 (problem-first) で、graded review にずれ込みやすかった。RRR は action-first で constructive code review の慣習に整合する。Request → Rationale → Result の順序は \"何をするか → なぜか → 結果はどうなるか\" を明確に区切るため、著者の triage が容易になる。

## ユーザー視点での影響

- レビュー結果が「approved か request changes か」が一目でわかる
- no findings のとき余計なファイルが生成されない（\`tmp/\` のノイズ削減）
- iteration の終了が明示的（agent が \`Approved\` を返す = ループ終了）
- 各 line comment が action-first になり、PR著者が「何を修正すれば閉じるか」を即座に把握できる

## Test plan

- [ ] /critic-design-review を blocker なしのコードで実行し、\`Approved\` のみが返ってファイルが書き出されないことを確認
- [ ] /critic-design-review を blocker ありのコードで実行し、\`Request changes\` + RRR形式の line comments + tmp/ ファイルが揃うことを確認
- [ ] resubmission で \`Approved\` を受け取った時に call-code-critic ループが正しく終了することを確認
- [ ] 出力された line comment が Request / Rationale / Result の3パートを欠かさず備えていることを確認

## References

- Adrienne Braganza Tacke, *Looks Good to Me: Constructive Code Reviews* (Manning, 2024)

🤖 Generated with [Claude Code](https://claude.com/claude-code)