### PR TITLE
fix(ssh): use id_ed25519 in IdentityFile to match registered key

### DIFF
--- a/ssh/config
+++ b/ssh/config
@@ -7,4 +7,4 @@ Host monitor-pi.local
 
 Host *
   UseKeychain yes
-  IdentityFile ~/.ssh/id_rsa
+  IdentityFile ~/.ssh/id_ed25519


### PR DESCRIPTION
## Summary
- `ssh/config` の `IdentityFile` が存在しない `~/.ssh/id_rsa` を指しており、SSH認証が `Permission denied (publickey)` で失敗していた
- 実際に存在しGitHubにも登録済みの `~/.ssh/id_ed25519` を指すよう修正
- 副次的に Claude Code のプラグインインストール時の SSH clone エラー（`SSH host key is not in your known_hosts file`）の根本原因となっていた状態を解消

## Background
- `~/.ssh/id_ed25519` は GitHub に `ed25519-auth-key-20260401` (auth) と `ed25519-signing-key-20260401` (signing) として登録済み
- `ssh -i ~/.ssh/id_ed25519 -o IdentitiesOnly=yes -T git@github.com` は成功するが、configの IdentityFile が `id_rsa` 固定指定されていたため、デフォルトでは id_rsa を見にいって失敗していた
- ed25519 は GitHub・OpenSSH の現在の推奨アルゴリズム

## Test plan
- [x] `ssh -T git@github.com` が認証成功すること（`Hi lacolaco! You've successfully authenticated`）
- [ ] このPRのレビューチェックアウトが SSH 経由で問題なく動くこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)