### PR TITLE
fix(ssh): use id_ed25519 as default identity

### DIFF
--- a/ssh/config
+++ b/ssh/config
@@ -7,4 +7,4 @@ Host monitor-pi.local
 
 Host *
   UseKeychain yes
-  IdentityFile ~/.ssh/id_rsa
+  IdentityFile ~/.ssh/id_ed25519


### PR DESCRIPTION
## Summary

- `Host *` の `IdentityFile` を `id_rsa` → `id_ed25519` に変更
- 既存の `id_rsa` は GitHub に登録されていないため、SSH 越しの GitHub アクセス（例: Claude Code plugin install などが `git@github.com:` 形式で clone する場合）が `Permission denied (publickey)` で失敗していた
- ローカルの `id_ed25519` は GitHub に登録済み（`ed25519-auth-key-20251227`）

## Background

Claude Code の `/plugin install` が SSH 経由で clone しようとして失敗したのが発見の契機。`ssh -vT git@github.com` で `id_rsa` のみが提示されて拒否されていることを確認した。

## Test plan

- [x] `ssh -T git@github.com` が成功すること（`Hi lacolaco! ...`）
- [ ] `git clone git@github.com:...` が通ること
- [ ] Claude Code plugin install（`notion-workspace-plugin@notion-plugin-marketplace`）が完走すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)